### PR TITLE
Basic Formatting of Trip Planning

### DIFF
--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -15,7 +15,6 @@ interface TripData{
 //     return tfStopRequester('rapidJSON', `&#x60;${searchString}&#x60;`, 'EPSG:4326', 'stop', 'true');
 // }
 
-
 /**
  * Function to plan a trip from one station to another using the Transport for NSW API.
  *
@@ -31,8 +30,8 @@ async function planTrip(fromId:string, toId:string, isArr:boolean, date:string, 
     const numberOfPossibleJourneys = 10;
     let depOrArr: 'dep' | 'arr' = 'dep';
     if (isArr) {
-        depOrArr = 'arr'
-    }
+        depOrArr = 'arr';
+    };
     return apiPlanner.tfnswTripRequest2('rapidJSON', 'EPSG:4326', depOrArr, 'any', fromId, 'any', toId, date, time, numberOfPossibleJourneys, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'true');
 }
 

--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -14,7 +14,7 @@ interface TripData{
 
 /**
  * Function to plan a trip from one station to another using the Transport for NSW API.
- * 
+ *
  * @param fromId - The ID of the station to depart from.
  * @param toId - The ID of the station to arrive at.
  * @returns A promise that resolves to the trip data.
@@ -30,7 +30,7 @@ async function planTrip(fromId:string, toId:string) {
 
 /**
  * Fetches trip data for a given journey and converts it to a processable format for the frontend.
- * 
+ *
  * @param props - The TripData object containing the station IDs for the trip.
  * @returns A promise that resolves to the trip data in a processable format.
  */
@@ -47,15 +47,15 @@ export async function FetchtripData(props: TripData): Promise<string[][]> {
 
 /**
  * Converts a TripRequestResponse object to processable format for the frontend
- * 
+ *
  * Note that the response object contains multiple journeys, each of which may consist of multiple legs.
- * 
+ *
  * - TripRequestResponse:
  *     - journeys: TripRequestResponseJourney[], an array of journeys representing all possible trips
- * 
+ *
  * - TripRequestResponseJourney:
  *    - legs: TripRequestResponseJourneyLeg[], an array of legs representing the different parts of a journey
- * 
+ *
  * - TripRequestResponseJourneyLeg:
  *    - coords: Coordinates of the leg.
  *    - destination: TripRequestResponseJourneyLegStop, the destination stop of the leg.
@@ -67,10 +67,10 @@ export async function FetchtripData(props: TripData): Promise<string[][]> {
  *    - origin: TripRequestResponseJourneyLegStop, the origin stop of the leg.
  *    - stopSequence: Sequence of stops in the leg.
  *    - transportation: Information about the transportation mode.
- * 
+ *
  * - TripRequestResponseJourneyLegStop:
  *   - name: Name of the stop, including the platform.
- * 
+ *
  * The function processes each journey and its legs, extracting the relevant information and converting it to a format that can be displayed on the frontend. It converts the departure and arrival times to Australia Eastern Time (AET) and the duration from seconds to hours and minutes.
  * @param res - The TripRequestResponse object containing the journeys and legs.
  * @returns An array of journeys, each represented as an array of strings for display on the frontend.
@@ -114,14 +114,13 @@ function tripResponseToJson(res: TripRequestResponse): string[][] {
             });
         }
         journeys.push(journeyDetails);
-
     });
     return journeys;
 }
 
 /**
  * Helper function to convert UTC time to Australia Eastern Time (AET).
- * 
+ *
  * @param utcTime - The UTC time string to convert.
  * @returns The time string converted to AET.
  *  */

--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -34,25 +34,30 @@ function tripResponseToJson(res: TripRequestResponse): string[][] {
     if (res.journeys == null) {
         return [['ERROR']];
     }
-    const legs : string[][] = [];
+    const legs: string[][] = [];
     res.journeys.forEach((x) => {
-        const legsInfo: string[] = [];
         if (x.legs == null) {
-            legsInfo.push('No Legs!');
+            legs.push(['No Legs!']);
         } else {
             x.legs.forEach((a) => {
                 const origin = a.origin;
                 const dest = a.destination;
                 const transport = a.transportation;
 
-                // Convert the arrival time to a more readable format
+                const departureTimeUTC = origin?.departureTimePlanned;
+                const departureTimeAET = departureTimeUTC ? convertToEasternTime(departureTimeUTC) : 'Unknown time';
+
                 const arrivalTimeUTC = dest?.arrivalTimePlanned;
                 const arrivalTimeAET = arrivalTimeUTC ? convertToEasternTime(arrivalTimeUTC) : 'Unknown time';
 
-                legsInfo.push(`From: ${origin?.name} To: ${dest?.name} arriving at: ${arrivalTimeAET} on ${transport?.name}.`);
+                // Convert the object to an array of strings so that it can be displayed with <li> tags
+                legs.push([
+                    `From: ${origin?.name}. Departing at: ${departureTimeAET}`,
+                    `To: ${dest?.name}. Arriving at ${arrivalTimeAET}`,
+                    `On: ${transport?.name}`
+                ]);
             });
         }
-        legs.push(legsInfo);
     });
     return legs;
 }

--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -44,10 +44,31 @@ function tripResponseToJson(res: TripRequestResponse): string[][] {
                 const origin = a.origin;
                 const dest = a.destination;
                 const transport = a.transportation;
-                legsInfo.push('From: ' + origin?.name + ' To: ' + dest?.name + ' arriving at: ' + dest?.arrivalTimePlanned + ' on ' + transport?.name + '.');
+
+                // Convert the arrival time to a more readable format
+                const arrivalTimeUTC = dest?.arrivalTimePlanned;
+                const arrivalTimeAET = arrivalTimeUTC ? convertToEasternTime(arrivalTimeUTC) : 'Unknown time';
+
+                legsInfo.push(`From: ${origin?.name} To: ${dest?.name} arriving at: ${arrivalTimeAET} on ${transport?.name}.`);
             });
         }
         legs.push(legsInfo);
     });
     return legs;
+}
+
+// Helper function to convert UTC time to Australia Eastern Time
+function convertToEasternTime(utcTime: string): string {
+    const date = new Date(utcTime);
+    const options: Intl.DateTimeFormatOptions = {
+        timeZone: 'Australia/Sydney',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    };
+    return new Intl.DateTimeFormat('en-AU', options).format(date);
 }

--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -12,14 +12,28 @@ interface TripData{
 //     return tfStopRequester('rapidJSON', `&#x60;${searchString}&#x60;`, 'EPSG:4326', 'stop', 'true');
 // }
 
+/**
+ * Function to plan a trip from one station to another using the Transport for NSW API.
+ * 
+ * @param fromId - The ID of the station to depart from.
+ * @param toId - The ID of the station to arrive at.
+ * @returns A promise that resolves to the trip data.
+ */
 async function planTrip(fromId:string, toId:string) {
     const config = new Configuration();
     config.apiKey = process.env.TPNSWAPIKEY;
     const apiPlanner = new DefApi(config);
+    // This limits the number of possible journeys to retrieve
     const numberOfPossibleJourneys = 10;
     return apiPlanner.tfnswTripRequest2('rapidJSON', 'EPSG:4326', 'dep', 'any', fromId, 'any', toId, undefined, undefined, numberOfPossibleJourneys, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'true');
 }
 
+/**
+ * Fetches trip data for a given journey and converts it to a processable format for the frontend.
+ * 
+ * @param props - The TripData object containing the station IDs for the trip.
+ * @returns A promise that resolves to the trip data in a processable format.
+ */
 export async function FetchtripData(props: TripData): Promise<string[][]> {
     const jsonObj = await planTrip((props.fromStation), (props.toStation));
     return tripResponseToJson(jsonObj);
@@ -30,39 +44,87 @@ export async function FetchtripData(props: TripData): Promise<string[][]> {
 // TripRequestResponseJourney is like this -> .legs = [TripRequestResponseJourneyLeg], this holds all the legs for each trip
 // TripRequestResponseJourneyLeg is like this -> .coords, .destination, .distance, .duration, .hints, .infos, .interchange, .origin, .stopSequence, .transportation
 // Both .destination and .origin are TripRequestResponseJourneyLegStop, which holds information about name, platform etc.
+
+/**
+ * Converts a TripRequestResponse object to processable format for the frontend
+ * 
+ * Note that the response object contains multiple journeys, each of which may consist of multiple legs.
+ * 
+ * - TripRequestResponse:
+ *     - journeys: TripRequestResponseJourney[], an array of journeys representing all possible trips
+ * 
+ * - TripRequestResponseJourney:
+ *    - legs: TripRequestResponseJourneyLeg[], an array of legs representing the different parts of a journey
+ * 
+ * - TripRequestResponseJourneyLeg:
+ *    - coords: Coordinates of the leg.
+ *    - destination: TripRequestResponseJourneyLegStop, the destination stop of the leg.
+ *    - distance: Distance of the leg.
+ *    - duration: Duration of the leg in seconds.
+ *    - hints: Additional hints or information.
+ *    - infos: Additional information about the leg.
+ *    - interchange: Information about interchanges.
+ *    - origin: TripRequestResponseJourneyLegStop, the origin stop of the leg.
+ *    - stopSequence: Sequence of stops in the leg.
+ *    - transportation: Information about the transportation mode.
+ * 
+ * - TripRequestResponseJourneyLegStop:
+ *   - name: Name of the stop, including the platform.
+ * 
+ * The function processes each journey and its legs, extracting the relevant information and converting it to a format that can be displayed on the frontend. It converts the departure and arrival times to Australia Eastern Time (AET) and the duration from seconds to hours and minutes.
+ * @param res - The TripRequestResponse object containing the journeys and legs.
+ * @returns An array of journeys, each represented as an array of strings for display on the frontend.
+ */
 function tripResponseToJson(res: TripRequestResponse): string[][] {
     if (res.journeys == null) {
         return [['ERROR']];
     }
-    const legs: string[][] = [];
-    res.journeys.forEach((x) => {
-        if (x.legs == null) {
-            legs.push(['No Legs!']);
-        } else {
-            x.legs.forEach((a) => {
-                const origin = a.origin;
-                const dest = a.destination;
-                const transport = a.transportation;
 
+    const journeys: string[][] = [];
+    res.journeys.forEach((journey) => {
+        const journeyDetails: string[] = [];
+        if (journey.legs == null) {
+            journeyDetails.push('No Legs!');
+        } else {
+            journey.legs.forEach((leg) => {
+                const origin = leg.origin;
+                const dest = leg.destination;
+                const transport = leg.transportation;
+
+                // Extract and convert the departure and arrival times to AET
                 const departureTimeUTC = origin?.departureTimePlanned;
                 const departureTimeAET = departureTimeUTC ? convertToEasternTime(departureTimeUTC) : 'Unknown time';
 
                 const arrivalTimeUTC = dest?.arrivalTimePlanned;
                 const arrivalTimeAET = arrivalTimeUTC ? convertToEasternTime(arrivalTimeUTC) : 'Unknown time';
 
+                // Convert duration from seconds to hours and minutes
+                const durationSeconds = leg.duration || 0;
+                const hours = Math.floor(durationSeconds / 3600);
+                const minutes = Math.floor((durationSeconds % 3600) / 60);
+                const formattedDuration = `${hours > 0 ? `${hours} hours ` : ''}${minutes} minutes`;
+
                 // Convert the object to an array of strings so that it can be displayed with <li> tags
-                legs.push([
+                journeyDetails.push(
                     `From: ${origin?.name}. Departing at: ${departureTimeAET}`,
                     `To: ${dest?.name}. Arriving at ${arrivalTimeAET}`,
-                    `On: ${transport?.name}`
-                ]);
+                    `On: ${transport?.name}`,
+                    `Duration: ${formattedDuration}`
+                );
             });
         }
+        journeys.push(journeyDetails);
+
     });
-    return legs;
+    return journeys;
 }
 
-// Helper function to convert UTC time to Australia Eastern Time
+/**
+ * Helper function to convert UTC time to Australia Eastern Time (AET).
+ * 
+ * @param utcTime - The UTC time string to convert.
+ * @returns The time string converted to AET.
+ *  */
 function convertToEasternTime(utcTime: string): string {
     const date = new Date(utcTime);
     const options: Intl.DateTimeFormatOptions = {

--- a/ripview/src/app/page.tsx
+++ b/ripview/src/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
                             <select name='fromStations' id='fromStations' onChange={(e) => setSelectedStation(e.target.value)}>
                                 <option key = {null} defaultValue={'---'}>{'---'}</option>
                                 {records.map((post) => (
-                                  <option key={post[2]} value={post[2]}>{post[1]}</option>
+                                  <option key={post[2]} value={post[2] + '~' + post[1]}>{post[1]}</option>
                                 ))}
                             </select>
                         </label>
@@ -52,7 +52,7 @@ export default function Home() {
                             <select name='toStations' id='toStations' onChange={(e) => setSelectedStation(e.target.value)}>
                                 <option key = {null} defaultValue={'---'}>{'---'}</option>
                                 {records.map((post) => (
-                                  <option key={post[2]} value={post[2]}>{post[1]}</option>
+                                  <option key={post[2]} value={post[2] + '~' + post[1]}>{post[1]}</option>
                                 ))}
                             </select>
                         </label>

--- a/ripview/src/app/page.tsx
+++ b/ripview/src/app/page.tsx
@@ -24,12 +24,6 @@ export default function Home() {
     const [selectedStation, setSelectedStation] = useState<string | null>(null);
     let records = StationJson.records;
     records = records.filter((a) => /Train|Metro/.test((a[10] as string)));
-
-    // const handleTripPlan = async (event: FormEvent<HTMLFormElement>) => {
-    //     event.preventDefault();
-    //     console.log(event.target.dispatchEvent);
-    //     console.log('Selected Station ID: ', selectedStation);
-    // };
     console.log(selectedStation);
     return (
         <div className={styles.page}>
@@ -58,7 +52,7 @@ export default function Home() {
                         </label>
                     </div>
                     <div className={styles.listInput}>
-                        <input type='radio' id='arr' name='depOrArr' value='arr' checked={true} ></input>
+                        <input type='radio' id='arr' name='depOrArr' value='arr' defaultChecked={true} ></input>
                         <label htmlFor="arr">arr</label>
                         <input type='radio' id='dep' name='depOrArr' value='dep'></input>
                         <label htmlFor="dep">dep</label>

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
             setjsonData(data);
         }
         fetchPosts();
-    }, [fromStation, toStation]);
+    }, [fromStation, toStation, isArr, date, time]);
     return (
         <div>
             <h1>Trip From {fromStation?.split('~')[1]} to {toStation?.split('~')[1]}!</h1>

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -12,18 +12,17 @@ export default function Home() {
     useEffect(() => {
         async function fetchPosts() {
             const tripData = {
-                fromStation: fromStation as string,
-                toStation: toStation as string,
+                fromStation: fromStation?.split('~')[0] as string,
+                toStation: toStation?.split('~')[0] as string,
             };
             const data = await FetchtripData(tripData);
             setjsonData(data);
         }
         fetchPosts();
     }, [fromStation, toStation]);
-    console.log(jsonData);
     return (
         <div>
-            <h1>Trip From {fromStation} to {toStation}!</h1>
+            <h1>Trip From {fromStation?.split('~')[1]} to {toStation?.split('~')[1]}!</h1>
             {jsonData.map((p, i) => (
                 <div key={i}>
                     <h2>Trip Option Number {i + 1}:</h2>


### PR DESCRIPTION
# Summary

- Change the format of the tripResponse result.
- Original format was being displayed in UTC format and changed this to display in 24 hour AET time since the users will be in the AET timezone.
- Reformatted the results for better readability.
- Added Departure Time.
- Added in support documentation to functions.
- Added in the duration of trips, had to convert from seconds to hour and minutes format for easier readability.
- Fixed linting issues.

## Next Steps
- Looking into tags and colour code tags according to Transport for NSW
- Apply tags and colour codes to front end 