### PR TITLE
Cascading Tabs on Click for the tripPlanning page

### DIFF
--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -72,18 +72,14 @@ export async function FetchtripData(props: TripData): Promise<string[][]> {
         intervals.push(i);
     }
 
-    // For arrive by: focus on times before the requested time
-    // For depart at: focus on times after the current time
     const baseTime = props.isArr ? requestedDate : sydneyNow;
 
-    // Add strategic time points
     intervals.forEach(hours => {
         const time = new Date(baseTime.getTime() + hours * 3600000);
         const { date, time: timeStr } = formatForAPI(time);
         timePoints.add(date + timeStr);
     });
 
-    // Convert to fetch ranges and sort
     const fetchRanges = Array.from(timePoints)
         .map(timeKey => ({
             date: timeKey.slice(0, 8),

--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -38,12 +38,29 @@ async function planTrip(fromId:string, toId:string, isArr:boolean, date:string, 
 
 /**
  * Fetches trip data for a given journey and converts it to a processable format for the frontend.
+ * Can fetch both past and future trips based on the date provided.
  *
  * @param props - The TripData object containing the station IDs for the trip.
  * @returns A promise that resolves to the trip data in a processable format.
  */
 export async function FetchtripData(props: TripData): Promise<string[][]> {
+    // Get current date for future trips
     const jsonObj = await planTrip(props.fromStation, props.toStation, props.isArr, props.date, props.time);
+    
+    // Calculate date for past trips (1 hour ago)
+    const pastDate = new Date();
+    pastDate.setHours(pastDate.getHours() - 1);
+    const pastDateStr = pastDate.toISOString().slice(0,10).replace(/-/g, '');
+    const pastTimeStr = pastDate.toTimeString().slice(0,5).replace(':', '');
+    
+    // Fetch past trips
+    const pastJsonObj = await planTrip(props.fromStation, props.toStation, props.isArr, pastDateStr, pastTimeStr);
+    
+    // Combine past and future trips
+    if (pastJsonObj.journeys && jsonObj.journeys) {
+        jsonObj.journeys = [...pastJsonObj.journeys, ...jsonObj.journeys];
+    }
+    
     return tripResponseToJson(jsonObj);
 }
 

--- a/ripview/src/app/api/apiCalls.tsx
+++ b/ripview/src/app/api/apiCalls.tsx
@@ -106,11 +106,22 @@ function tripResponseToJson(res: TripRequestResponse): string[][] {
                 const arrivalTimeUTC = dest?.arrivalTimePlanned;
                 const arrivalTimeAET = arrivalTimeUTC ? convertToEasternTime(arrivalTimeUTC) : 'Unknown time';
 
-                // Convert duration from seconds to hours and minutes
-                const durationSeconds = leg.duration || 0;
-                const hours = Math.floor(durationSeconds / 3600);
-                const minutes = Math.floor((durationSeconds % 3600) / 60);
-                const formattedDuration = `${hours > 0 ? `${hours} hours ` : ''}${minutes} minutes`;
+                // Calculate duration from departure and arrival times
+                let formattedDuration = 'Unknown duration';
+                if (departureTimeUTC && arrivalTimeUTC) {
+                    const departureTime = new Date(departureTimeUTC);
+                    const arrivalTime = new Date(arrivalTimeUTC);
+                    
+                    // Truncate seconds for both times so that there are no issues with calculating the duration such as rounding issues
+                    departureTime.setSeconds(0);
+                    arrivalTime.setSeconds(0);
+                    
+                    // Calculate the duration in minutes and hours and using Math.floor to ensure that there are no issues with rounding
+                    const durationMinutes = Math.floor((arrivalTime.getTime() - departureTime.getTime()) / (1000 * 60));
+                    const hours = Math.floor(durationMinutes / 60);
+                    const minutes = durationMinutes % 60;
+                    formattedDuration = `${hours > 0 ? `${hours} hours ` : ''}${minutes} minutes`;
+                }
 
                 // Convert the object to an array of strings so that it can be displayed with <li> tags
                 journeyDetails.push(

--- a/ripview/src/app/layout.tsx
+++ b/ripview/src/app/layout.tsx
@@ -3,6 +3,16 @@ import { Geist } from 'next/font/google';
 import './globals.css';
 import { ReactNode } from 'react';
 
+import type { Viewport } from 'next';
+
+export const viewport: Viewport = {
+    width: 'device-width',
+    userScalable: false,
+    initialScale: 1,
+    maximumScale: 1,
+    viewportFit: 'cover'
+};
+
 const geistSans = Geist({
     variable: '--font-geist-sans',
     subsets: ['latin'],
@@ -29,6 +39,14 @@ export default function RootLayout({
                     referrerPolicy="no-referrer"
                 />
                 <link rel='manifest' href='/site.webmanifest'/>
+                <meta
+                    name = 'apple-mobile-web-app-status-bar-style'
+                    content = 'black-translucent'
+                />
+                <link
+                    rel='apple-touch-icon'
+                    href='/favicon/apple-touch-icon.png'
+                />
             </head>
             <body>
                 {children}

--- a/ripview/src/app/mapInput/layout.tsx
+++ b/ripview/src/app/mapInput/layout.tsx
@@ -1,10 +1,12 @@
-import type { Metadata } from 'next';
 import '../globals.css';
 import { ReactNode } from 'react';
+import type { Viewport } from 'next';
 
-export const metadata: Metadata = {
-    title: 'RipView',
-    description: 'Transcend the TripView Experience',
+export const viewport: Viewport = {
+    width: 'device-width',
+    userScalable: false,
+    initialScale: 1,
+    viewportFit: 'cover'
 };
 
 export default function TripPlanningLayout({

--- a/ripview/src/app/mapInput/mapInput.module.css
+++ b/ripview/src/app/mapInput/mapInput.module.css
@@ -1,31 +1,76 @@
 .page {
-    width: 100%;
-    height: 100vh;
-    display: flex;
+    --gray-rgb: 0, 0, 0;
+    --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
+    --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
+
+    --button-primary-hover: #383838;
+    --button-secondary-hover: #f2f2f2;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    align-items: start;
+    justify-items: center;
+    min-height: 100svh;
+    padding: 0 0 2rem 0;
+    gap: 4rem;
+    font-family: var(--font-geist-sans);
+}
+
+.main {
+    /* display: flex; */
+    position: relative;
     flex-direction: column;
-    background-color: var(--background);
-}
-
-.mapContainer {
-    flex: 1;
-    width: 100%;
-    padding: 1rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    overflow: auto;
-}
-
-.mapContainer > svg {
+    /* gap: 2rem; */
     width: 100%;
     height: 100%;
-    max-width: 1200px;
+    padding: 1rem 2rem 0 2rem;
 }
 
-.mapDiv {
-    background-color: black;
+.zoomButtons {
+    display: flex;
+    position: absolute;
+    flex-direction: column;
+    top: 0;
+    right: 2rem;
+    z-index: 1;
+}
+
+.panButtons {
+    display: flex;
+    position: absolute;
+    flex-direction: column;
+    top: 0;
+    left: 2rem;
+    z-index: 1;
+}
+
+.map {
+    /* margin: auto; */
+    position: relative;
+    width: 100%;
+    height: auto;
     pointer-events: all;
-    margin: auto;
-    width: 70%;
-    font-family: inherit;
+    z-index: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    .page {
+        --gray-rgb: 255, 255, 255;
+        --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
+        --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
+
+        --button-primary-hover: #ccc;
+        --button-secondary-hover: #1a1a1a;
+    }
+}
+
+@media (max-width: 37.5rem) {
+    .page {
+        padding: 0 0 1rem 0;
+    }
+
+    .main {
+        align-items: center;
+        padding: 0 1rem;
+        margin-bottom: 1rem;
+    }
 }

--- a/ripview/src/app/mapInput/mapInput.module.css
+++ b/ripview/src/app/mapInput/mapInput.module.css
@@ -1,3 +1,27 @@
+.page {
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--background);
+}
+
+.mapContainer {
+    flex: 1;
+    width: 100%;
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: auto;
+}
+
+.mapContainer > svg {
+    width: 100%;
+    height: 100%;
+    max-width: 1200px;
+}
+
 .mapDiv {
     background-color: black;
     pointer-events: all;

--- a/ripview/src/app/mapInput/page.tsx
+++ b/ripview/src/app/mapInput/page.tsx
@@ -1,14 +1,24 @@
 'use client';
 import styles from './mapInput.module.css';
 import MySVG from '../../../public/map/Sydney_Trains_Network_Map.svg';
-import { useCallback, MouseEvent } from 'react';
+import { useCallback, MouseEvent, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import BackButton from '@/components/BackButton';
+import Loading from '@/components/Loading';
 
 export default function MapInput() {
     const router = useRouter();
+    const [isLoading, setIsLoading] = useState(true);
     let fromId = '';
     let toId = '';
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 1000);
+        return () => clearTimeout(timer);
+    }, []);
+
     const handleSVGClick = useCallback((event: MouseEvent<SVGSVGElement>) => {
         let target = event.target;
         const targetStore = event.target as SVGElement;
@@ -51,13 +61,17 @@ export default function MapInput() {
     }, []);
 
     return (
-        <div className={styles.mapInputContainer}>
-            <BackButton />
-            <div className={styles.mapDiv}>
-                <MySVG
-                    onClick={handleSVGClick}
-                />
-            </div>
+        <div className={styles.page}>
+            {isLoading ? (
+                <Loading message="Loading map..." />
+            ) : (
+                <>
+                    <BackButton />
+                    <div className={styles.mapContainer}>
+                        <MySVG onClick={handleSVGClick} />
+                    </div>
+                </>
+            )}
         </div>
     );
 }

--- a/ripview/src/app/mapInput/page.tsx
+++ b/ripview/src/app/mapInput/page.tsx
@@ -1,24 +1,55 @@
 'use client';
 import styles from './mapInput.module.css';
 import MySVG from '../../../public/map/Sydney_Trains_Network_Map.svg';
-import { useCallback, MouseEvent, useState, useEffect } from 'react';
+import { useCallback, MouseEvent } from 'react';
 import { useRouter } from 'next/navigation';
-import BackButton from '@/components/BackButton';
-import Loading from '@/components/Loading';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import { useState } from 'react';
 
 export default function MapInput() {
     const router = useRouter();
-    const [isLoading, setIsLoading] = useState(true);
     let fromId = '';
     let toId = '';
+    const [viewBox, setViewBox] = useState('0 0 800 800');
 
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setIsLoading(false);
-        }, 1000);
-        return () => clearTimeout(timer);
-    }, []);
-
+    const zoom = (factor: number) => {
+        setViewBox((prev: string) => {
+            const [x, y, w, h] = prev.split(' ').map(Number);
+            const zoomFactor = w * factor; // Adjust width/height
+            const newW = Math.max(10, w + zoomFactor);
+            const newH = Math.max(10, h + zoomFactor);
+            return `${x} ${y} ${newW} ${newH}`;
+        });
+    };
+    const left = (num: number) => {
+        setViewBox((prev: string) => {
+            const [x, y, w, h] = prev.split(' ').map(Number);
+            const newX = x - num;
+            return `${newX} ${y} ${w} ${h}`;
+        });
+    };
+    const right = (num: number) => {
+        setViewBox((prev: string) => {
+            const [x, y, w, h] = prev.split(' ').map(Number);
+            const newX = x + num;
+            return `${newX} ${y} ${w} ${h}`;
+        });
+    };
+    const up = (num: number) => {
+        setViewBox((prev: string) => {
+            const [x, y, w, h] = prev.split(' ').map(Number);
+            const newY = y - num;
+            return `${x} ${newY} ${w} ${h}`;
+        });
+    };
+    const down = (num: number) => {
+        setViewBox((prev: string) => {
+            const [x, y, w, h] = prev.split(' ').map(Number);
+            const newY = y + num;
+            return `${x} ${newY} ${w} ${h}`;
+        });
+    };
     const handleSVGClick = useCallback((event: MouseEvent<SVGSVGElement>) => {
         let target = event.target;
         const targetStore = event.target as SVGElement;
@@ -62,16 +93,29 @@ export default function MapInput() {
 
     return (
         <div className={styles.page}>
-            {isLoading ? (
-                <Loading message="Loading map..." />
-            ) : (
-                <>
-                    <BackButton />
-                    <div className={styles.mapContainer}>
-                        <MySVG onClick={handleSVGClick} />
+            <Header text='Home' link='/'/>
+            <main className={styles.main}>
+                <div className={styles.zoomButtons}>
+                    Zoom:
+                    <button onClick={() => zoom(-0.1)}>+</button>
+                    <button onClick={() => zoom(0.1)}>-</button>
+                </div>
+                <div className={styles.panButtons}>
+                    Pan:
+                    <button onClick={() => up(15)}>↑</button>
+                    <div>
+                        <button onClick={() => left(15)}>←</button>
+                        <button onClick={() => right(15)}>→</button>
                     </div>
-                </>
-            )}
+                    <button onClick={() => down(15)}>↓</button>
+                </div>
+                <MySVG className={styles.map}
+                    viewBox={viewBox}
+                    onClick={handleSVGClick}
+                />
+                
+            </main>
+            <Footer/>
         </div>
     );
 }

--- a/ripview/src/app/page.module.css
+++ b/ripview/src/app/page.module.css
@@ -2,16 +2,15 @@
     --gray-rgb: 0, 0, 0;
     --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
     --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-
     --button-primary-hover: #383838;
     --button-secondary-hover: #f2f2f2;
 
     display: grid;
-    grid-template-rows: 1.25rem 1fr 1.25rem;
-    align-items: center;
+    grid-template-rows: auto 1fr auto;
+    align-items: start;
     justify-items: center;
     min-height: 100svh;
-    padding: 5rem;
+    padding: 10rem 0 2rem 0;
     gap: 4rem;
     font-family: var(--font-geist-sans);
 }
@@ -19,10 +18,11 @@
 .main {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 2rem;
-    grid-row-start: 2;
     width: 100%;
-    max-width: 37.5rem;
+    max-width: 75rem;
+    padding: 0 2rem;
 }
 
 .main h2 {
@@ -54,7 +54,9 @@
 .main form {
     display: flex;
     flex-direction: column;
+    align-items: center;
     width: 100%;
+    gap: 1rem;
 }
 
 .ctas {
@@ -104,7 +106,6 @@ a.secondary {
     z-index: 10;
     width: 100%;
 }
-
 
 .navBar h1 {
     flex: 1;
@@ -298,7 +299,12 @@ a.secondary {
     width: 100%;
 }
 
-/* Enable hover only on non-touch devices */
+@media (display-mode: standalone) {
+    .page {
+        padding-top: 8rem;
+    }
+}
+
 @media (hover: hover) and (pointer: fine) {
     a.primary:hover {
         background: var(--button-primary-hover);
@@ -317,13 +323,11 @@ a.secondary {
 }
 
 @media (max-width: 37.5rem) { /* 600px */
-    .page {
-        padding: 2rem;
-        padding-bottom: 5rem;
-    }
 
     .main {
         align-items: center;
+        padding: 2rem;
+        padding-bottom: 5rem;
     }
 
     .main ol {
@@ -397,7 +401,6 @@ a.secondary {
         border-color: var(--foreground);
     }
 }
-
 
 @media (prefers-color-scheme: light) {
     .lightLogo {

--- a/ripview/src/app/page.tsx
+++ b/ripview/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, ChangeEvent } from 'react';
+import { useState, useEffect, ChangeEvent, FormEvent } from 'react';
 import styles from './page.module.css';
 import Form from 'next/form';
 import { getStationIdEntries } from '@/utils/getData';
@@ -44,7 +44,7 @@ export default function Home() {
         }
     };
 
-    const handleSubmit = (e: React.FormEvent) => {
+    const handleSubmit = (e: FormEvent) => {
         if (!fromStationId || !toStationId) {
             e.preventDefault();
             alert('Please select both stations');
@@ -53,8 +53,8 @@ export default function Home() {
 
     return (
         <div className={styles.page}>
+            <Header text='Map' link='/mapInput'/>
             <main className={styles.main}>
-                <Header />
                 <h2>Plan a trip!!</h2>
                 <Form action='/tripPlanning' onSubmit={handleSubmit}>
                     <StationSelect

--- a/ripview/src/app/tripPlanning/layout.tsx
+++ b/ripview/src/app/tripPlanning/layout.tsx
@@ -1,5 +1,14 @@
 import { ReactNode } from 'react';
 import '../globals.css';
+import type { Viewport } from 'next';
+
+export const viewport: Viewport = {
+    width: 'device-width',
+    userScalable: false,
+    initialScale: 1,
+    maximumScale: 1,
+    viewportFit: 'cover'
+};
 
 export default function TripPlanningLayout({
     children,

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -46,7 +46,8 @@ export default function Home() {
     }, []);
 
     useEffect(() => {
-        const timer = setInterval(() => {
+        // Function to update time and find next trip
+        const updateTimeAndTrips = () => {
             const now = new Date();
             setCurrentTime(now);
             
@@ -71,9 +72,28 @@ export default function Home() {
 
                 setNextTripIndex(nextIndex >= 0 ? nextIndex : null);
             }
-        }, 60000); // Update every minute
+        };
 
-        return () => clearInterval(timer);
+        // Calculate delay until the start of the next minute
+        const now = new Date();
+        const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+
+        // Initial update
+        updateTimeAndTrips();
+
+        // Set timeout to sync with the start of the next minute
+        const initialTimeout = setTimeout(() => {
+            updateTimeAndTrips();
+            
+            // Then set interval to run every minute, exactly on the minute
+            const interval = setInterval(updateTimeAndTrips, 60000);
+            
+            // Cleanup interval on component unmount
+            return () => clearInterval(interval);
+        }, msUntilNextMinute);
+
+        // Cleanup timeout on component unmount
+        return () => clearTimeout(initialTimeout);
     }, [jsonData]);
 
     const isToday = (date: Date) => {

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -282,29 +282,28 @@ export default function Home() {
             return;
         }
 
-        // First close the current tab
+        // First close the current tab and immediately open the new one
         setExpandedTrip(null);
-
-        // Wait for close animation
+        
         setTimeout(() => {
-            const tripElement = document.getElementById(`trip-main-${tripIndex}`);
-            if (tripElement) {
-                // Get the computed header offset from CSS
-                const computedStyle = getComputedStyle(document.documentElement);
-                const headerOffset = parseInt(computedStyle.getPropertyValue('--header-offset')) || 170;
-                const elementPosition = tripElement.getBoundingClientRect().top + window.pageYOffset;
-                
-                window.scrollTo({
-                    top: elementPosition - headerOffset,
-                    behavior: 'smooth'
-                });
-
-                // Wait for scroll to complete before opening new tab
-                setTimeout(() => {
-                    setExpandedTrip(tripIndex);
-                });
-            }
-        }, 300);
+            setExpandedTrip(tripIndex);
+            
+            // After opening, scroll to the new position
+            setTimeout(() => {
+                const tripElement = document.getElementById(`trip-main-${tripIndex}`);
+                if (tripElement) {
+                    // Get the computed header offset from CSS
+                    const computedStyle = getComputedStyle(document.documentElement);
+                    const headerOffset = parseInt(computedStyle.getPropertyValue('--header-offset')) || 170;
+                    const elementPosition = tripElement.getBoundingClientRect().top + window.pageYOffset;
+                    
+                    window.scrollTo({
+                        top: elementPosition - headerOffset,
+                        behavior: 'smooth'
+                    });
+                }
+            }, 150); // Small delay to let the new tab start opening
+        }, 500);
     };
 
     return (

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { FetchtripData } from '../api/apiCalls';
 import { useState, useEffect } from 'react';
 import { getStationNameFromId } from '@/utils/getData';
+import trainLineColours from '@/config/trainLineColours';
 import styles from './tripPlanning.module.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
@@ -21,6 +22,7 @@ export default function Home() {
 
     const fromName = getStationNameFromId(fromStation as string);
     const toName = getStationNameFromId(toStation as string);
+    const [expandedTrip, setExpandedTrip] = useState<number | null>(null);
 
     useEffect(() => {
         // Set current page
@@ -147,29 +149,93 @@ export default function Home() {
         if (info.startsWith('From:')) {
             const [location, time] = info.split('Departing at:');
             const formattedTime = time.trim().replace(/:\d{2}(?=\s|$)/, ''); // Removes seconds
-            return (
-                <>
-                    <div>{location.trim()}</div>
-                    <div className={styles.timeInfo}>
-                        Departing at: {formattedTime}
-                    </div>
-                </>
-            );
+            // Extract just the station name and platform
+            const match = location.match(/From: (.*?), Platform (\d+)/);
+            if (match) {
+                const [_, station, platform] = match;
+                return (
+                    <>
+                        <div>{`${station}, Platform ${platform}`}</div>
+                        <div className={styles.timeInfo}>
+                            {formattedTime}
+                        </div>
+                    </>
+                );
+            }
         }
         if (info.startsWith('To:')) {
             const [location, time] = info.split('Arriving at');
             const formattedTime = time.trim().replace(/:\d{2}(?=\s|$)/, ''); // Removes seconds
-            return (
-                <>
-                    <div>{location.trim()}</div>
-                    <div className={styles.timeInfo}>
-                        Arriving at: {formattedTime}
-                    </div>
-                </>
-            );
+            // Extract just the station name and platform
+            const match = location.match(/To: (.*?), Platform (\d+)/);
+            if (match) {
+                const [_, station, platform] = match;
+                return (
+                    <>
+                        <div>{`${station}, Platform ${platform}`}</div>
+                        <div className={styles.timeInfo}>
+                            {formattedTime}
+                        </div>
+                    </>
+                );
+            }
         }
-        return <div>{info}</div>;
+        if (info.startsWith('Duration:')) {
+            return <div>{info}</div>;
+        }
+        return null;
     };
+
+    // Function to extract train line info
+    const extractTrainLine = (info: string) => {
+        const match = info.match(/Sydney Trains Network\s+(.+)/);
+        return match ? match[1] : info;
+    };
+
+    // Function to calculate total duration from multiple legs
+    const calculateTotalDuration = (trip: string[]) => {
+        let totalMinutes = 0;
+
+        // Find all duration strings in the trip
+        trip.forEach(info => {
+            if (info.startsWith('Duration:')) {
+                const minutes = parseInt(info.replace('Duration:', ''));
+                if (!isNaN(minutes)) {
+                    totalMinutes += minutes;
+                }
+            }
+        });
+
+        if (totalMinutes === 0) return '0m';
+
+        const hours = Math.floor(totalMinutes / 60);
+        const remainingMinutes = totalMinutes % 60;
+
+        if (hours === 0) {
+            return `${remainingMinutes}m`;
+        }
+        return `${hours}h ${remainingMinutes}m`;
+    };
+
+    // Function to format time without seconds
+    const formatTimeWithoutSeconds = (timeStr: string) => {
+        if (!timeStr) return 'N/A';
+        const [hours, minutes] = timeStr.split(':');
+        return `${hours}:${minutes}`;
+    };
+
+    // Function to get train line color
+    const getTrainLineColor = (trainLine: string) => {
+        const color = Object.entries(trainLineColours).find(([key]) =>
+            trainLine.includes(key)
+        );
+        return color ? color[1] : '#6f818d';
+    };
+
+    const handleTripClick = (tripIndex: number) => {
+        setExpandedTrip(expandedTrip === tripIndex ? null : tripIndex);
+    };
+
     return (
         <div className={styles.page}>
             <Header />
@@ -182,35 +248,104 @@ export default function Home() {
                     <div className={styles.tripDetails}>
                         <p>Showing trips for: {getTimePreferenceText()}</p>
                     </div>
-                    {jsonData.map((trip, tripIndex) => (
-                        <div key={tripIndex} className={styles.tripOption}>
-                            <h2>Trip Option Number {tripIndex + 1}:</h2>
-                            {hasMultipleLegs(trip) && (
-                                <div className={styles.legsInfo}>
-                                    Requires {getNumberOfLegs(trip) - 1} train change{getNumberOfLegs(trip) - 1 > 1 ? 's' : ''}
-                                </div>
-                            )}
-                            <ul className={styles.tripList}>
-                                {trip.map((info, infoIndex) => {
-                                    const isNewLeg = info.startsWith('From:') && infoIndex !== 0;
-                                    const isTransportation = info.startsWith('On:');
-                                    const isDuration = info.startsWith('Duration:');
+                    {jsonData.map((trip, tripIndex) => {
+                        // Extract departure and arrival info
+                        const departureInfo = trip.find(info => info.startsWith('From:'))?.split('Departing at:');
+                        const arrivalInfo = trip.find(info => info.startsWith('To:'))?.split('Arriving at');
+                        const transportInfo = trip.find(info => info.startsWith('On:'))?.replace('On: ', '');
+                        const durationInfo = trip.find(info => info.startsWith('Duration:'))?.replace('Duration: ', '');
 
-                                    return (
-                                        <li key={infoIndex}>
-                                            {isNewLeg && <hr className={styles.legDivider} />}
-                                            <div className={`
-                                                ${isTransportation ? styles.transportInfo : ''}
-                                                ${isDuration ? styles.durationInfo : ''}
-                                            `}>
-                                                {formatTripInfo(info)}
+                        return (
+                            <div
+                                key={tripIndex}
+                                className={`${styles.tripOption} ${expandedTrip === tripIndex ? styles.expanded : ''}`}
+                                onClick={() => handleTripClick(tripIndex)}
+                                role="button"
+                                tabIndex={0}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        handleTripClick(tripIndex);
+                                    }
+                                }}
+                            >
+                                <div className={styles.tripSummary}>
+                                    <div className={styles.tripMainInfo}>
+                                        <div className={styles.stationContainer}>
+                                            <div className={styles.stationName}>
+                                                {departureInfo?.[0].replace('From:', '').trim()}
                                             </div>
-                                        </li>
-                                    );
-                                })}
-                            </ul>
-                        </div>
-                    ))}
+                                            <div className={styles.stationTime}>
+                                                {formatTimeWithoutSeconds(departureInfo?.[1].trim().split(', ')[1] || 'N/A')}
+                                            </div>
+                                        </div>
+                                        <div className={`${styles.stationContainer} ${styles.right}`}>
+                                            <div className={styles.stationName}>
+                                                {arrivalInfo?.[0].replace('To:', '').trim()}
+                                            </div>
+                                            <div className={styles.stationTime}>
+                                                {formatTimeWithoutSeconds(arrivalInfo?.[1].trim().split(', ')[1] || 'N/A')}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {hasMultipleLegs(trip) && (
+                                        <div className={styles.legsInfo}>
+                                            {getNumberOfLegs(trip) - 1} change{getNumberOfLegs(trip) - 1 > 1 ? 's' : ''}
+                                        </div>
+                                    )}
+                                    <div className={styles.expandIcon}>
+                                        {expandedTrip === tripIndex ? '▼' : '▶'}
+                                    </div>
+                                </div>
+                                <div className={`${styles.tripDetails} ${expandedTrip === tripIndex ? styles.visible : ''}`}>
+                                    <div className={styles.tripExtendedInfo}>
+                                        <div className={styles.transportLines}>
+                                            {trip
+                                                .filter(info => info.startsWith('On:'))
+                                                .map((transportInfo, index) => {
+                                                    const trainLine = extractTrainLine(transportInfo.replace('On: ', ''));
+                                                    const color = getTrainLineColor(trainLine);
+
+                                                    return (
+                                                        <div key={index} className={styles.transportLine}>
+                                                            <div
+                                                                className={styles.trainLineIndicator}
+                                                                style={{ backgroundColor: color }}
+                                                            />
+                                                            <span>{trainLine}</span>
+                                                        </div>
+                                                    );
+                                                })}
+                                        </div>
+                                        <div className={styles.totalTripDuration}>
+                                            <i className="fas fa-clock"></i>
+                                            <span>Total Duration: {calculateTotalDuration(trip)}</span>
+                                        </div>
+                                    </div>
+                                    <ul className={styles.tripList}>
+                                        {trip.map((info, infoIndex) => {
+                                            const isNewLeg = info.startsWith('From:') && infoIndex !== 0;
+                                            const isTransportation = info.startsWith('On:');
+                                            const isDuration = info.startsWith('Duration:');
+
+                                            if (isTransportation) return null;
+
+                                            return (
+                                                <li key={infoIndex}>
+                                                    {isNewLeg && <hr className={styles.legDivider} />}
+                                                    <div className={`
+                                                        ${isTransportation ? styles.transportInfo : ''}
+                                                        ${isDuration ? styles.durationInfo : ''}
+                                                    `}>
+                                                        {formatTripInfo(info)}
+                                                    </div>
+                                                </li>
+                                            );
+                                        })}
+                                    </ul>
+                                </div>
+                            </div>
+                        );
+                    })}
                 </div>
             </main>
             <Footer />

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -397,25 +397,27 @@ export default function Home() {
             return;
         }
 
-        // First close the current tab and immediately open the new one
+        // Step 1: Close any open trip
         setExpandedTrip(null);
+
+        // Step 2: Wait for the closing animation
         setTimeout(() => {
+            // Step 3: Open the new trip
             setExpandedTrip(tripIndex);
-            
-            // After opening, scroll to the new position
+
+            // Step 4: Wait for the opening animation and DOM update
             setTimeout(() => {
                 const tripElement = document.getElementById(`trip-main-${tripIndex}`);
                 if (tripElement) {
-                    const computedStyle = getComputedStyle(document.documentElement);
-                    const headerOffset = parseInt(computedStyle.getPropertyValue('--header-offset')) || 200;
-                    const elementPosition = tripElement.getBoundingClientRect().top + window.pageYOffset;
+                    const offset = 170;
+                    const elementTop = tripElement.getBoundingClientRect().top + window.scrollY;
                     window.scrollTo({
-                        top: elementPosition - headerOffset,
+                        top: elementTop - offset,
                         behavior: 'smooth'
                     });
                 }
-            }, 100);
-        }, 300);
+            }, 200); // Longer wait to ensure the animation is complete
+        }, 300); // Longer wait to ensure the closing is complete
     };
 
     // Calculate time until departure

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -672,6 +672,17 @@ export default function Home() {
                                             </div>
                                             <div className={styles.stationTime}>
                                                 {firstDepartureInfo && `${formatTimeWithDate(firstDepartureInfo[1])}`}
+                                                {!isArr && firstDepartureInfo?.[1] && time && timePreference !== 'current' && (() => {
+                                                    const departureTime = firstDepartureInfo[1];
+                                                    if (!departureTime) return null;
+                                                    const diff = calculateTimeDifference(departureTime, time);
+                                                    if (diff === null) return null;
+                                                    return (
+                                                        <div className={styles.timeDifference}>
+                                                            ({formatTimeDifference(Math.abs(diff))} after requested time)
+                                                        </div>
+                                                    );
+                                                })()}
                                             </div>
                                         </div>
                                         <div className={`${styles.stationContainer} ${styles.right}`}>
@@ -680,7 +691,7 @@ export default function Home() {
                                             </div>
                                             <div className={styles.stationTime}>
                                                 {lastArrivalInfo && `${formatTimeWithDate(lastArrivalInfo[1])}`}
-                                                {isArr && lastArrivalInfo?.[1] && time && (() => {
+                                                {isArr && lastArrivalInfo?.[1] && time && timePreference !== 'current' && (() => {
                                                     const arrivalTime = lastArrivalInfo[1];
                                                     if (!arrivalTime) return null;
                                                     const diff = calculateTimeDifference(arrivalTime, time);

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -276,7 +276,35 @@ export default function Home() {
     };
 
     const handleTripClick = (tripIndex: number) => {
-        setExpandedTrip(expandedTrip === tripIndex ? null : tripIndex);
+        // If clicking the same trip, just close it
+        if (expandedTrip === tripIndex) {
+            setExpandedTrip(null);
+            return;
+        }
+
+        // First close the current tab
+        setExpandedTrip(null);
+
+        // Wait for close animation
+        setTimeout(() => {
+            const tripElement = document.getElementById(`trip-main-${tripIndex}`);
+            if (tripElement) {
+                // Get the computed header offset from CSS
+                const computedStyle = getComputedStyle(document.documentElement);
+                const headerOffset = parseInt(computedStyle.getPropertyValue('--header-offset')) || 170;
+                const elementPosition = tripElement.getBoundingClientRect().top + window.pageYOffset;
+                
+                window.scrollTo({
+                    top: elementPosition - headerOffset,
+                    behavior: 'smooth'
+                });
+
+                // Wait for scroll to complete before opening new tab
+                setTimeout(() => {
+                    setExpandedTrip(tripIndex);
+                });
+            }
+        }, 300);
     };
 
     return (
@@ -306,6 +334,7 @@ export default function Home() {
                         return (
                             <div
                                 key={tripIndex}
+                                id={`trip-${tripIndex}`}
                                 className={`${styles.tripOption} ${expandedTrip === tripIndex ? styles.expanded : ''}`}
                                 onClick={() => handleTripClick(tripIndex)}
                                 role="button"
@@ -317,7 +346,10 @@ export default function Home() {
                                 }}
                             >
                                 <div className={styles.tripSummary}>
-                                    <div className={styles.tripMainInfo}>
+                                    <div 
+                                        id={`trip-main-${tripIndex}`}
+                                        className={styles.tripMainInfo}
+                                    >
                                         <div className={styles.stationContainer}>
                                             <div className={styles.stationName}>
                                                 {formatStationName(firstDepartureInfo?.[0])}
@@ -325,6 +357,11 @@ export default function Home() {
                                             <div className={styles.stationTime}>
                                                 {formatTimeWithoutSeconds(firstDepartureInfo?.[1].trim().split(', ')[1] || 'N/A')}
                                             </div>
+                                            {hasMultipleLegs(trip) && (
+                                                <div className={styles.legsInfo}>
+                                                    {getNumberOfLegs(trip) - 1} train line change{getNumberOfLegs(trip) - 1 > 1 ? 's' : ''}
+                                                </div>
+                                            )}
                                         </div>
                                     </div>
                                     <div className={styles.rightSection}>
@@ -345,11 +382,6 @@ export default function Home() {
                                                             {timeUntil && (
                                                                 <div className={styles.timeUntilDeparture}>
                                                                     Departs in: {timeUntil}
-                                                                </div>
-                                                            )}
-                                                            {hasMultipleLegs(trip) && (
-                                                                <div className={styles.legsInfo}>
-                                                                    {getNumberOfLegs(trip) - 1} train line change{getNumberOfLegs(trip) - 1 > 1 ? 's' : ''}
                                                                 </div>
                                                             )}
                                                         </>

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -10,6 +10,7 @@ import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import ScrollToTop from '@/components/ScrollToTop';
 import SubHeader from '@/components/SubHeader';
+import Loading from '@/components/Loading';
 
 export default function Home() {
     const [jsonData, setjsonData] = useState([['Loading...']]);
@@ -697,217 +698,225 @@ export default function Home() {
         }
     };
 
+    const isLoading = jsonData[0][0] === 'Loading...';
+
     return (
         <div className={styles.page}>
-            <Header title={`Trip From ${fromName} to ${toName}!`} />
-            <SubHeader 
-                timeInfo={getTimePreferenceText()} 
-                onClosestTrip={scrollToClosestTrip}
-                hasClosestTrip={nextTripIndex !== null}
-            />
-            <main className={styles.main}>
-                <div className={styles.tripContent}>
-                    <div className={styles.tripDetails}>
-                        <p>Showing trips for: {getTimePreferenceText()}</p>
-                    </div>
-                    {/* Display future trips */}
-                    {jsonData.map((trip, tripIndex) => {
-                        // Extract departure and arrival info
-                        const departureInfos = trip.filter(info => info.startsWith('From:'));
-                        const arrivalInfos = trip.filter(info => info.startsWith('To:'));
-                        
-                        // Get the first departure and last arrival for multi-leg journeys
-                        const firstDepartureInfo = departureInfos[0]?.split('Departing at:');
-                        const lastArrivalInfo = arrivalInfos[arrivalInfos.length - 1]?.split('Arriving at');
+            {isLoading ? (
+                <Loading message="Finding your trips..." />
+            ) : (
+                <>
+                    <Header title={`Trip From ${fromName} to ${toName}!`} />
+                    <SubHeader 
+                        timeInfo={getTimePreferenceText()} 
+                        onClosestTrip={scrollToClosestTrip}
+                        hasClosestTrip={nextTripIndex !== null}
+                    />
+                    <main className={styles.main}>
+                        <div className={styles.tripContent}>
+                            <div className={styles.tripDetails}>
+                                <p>Showing trips for: {getTimePreferenceText()}</p>
+                            </div>
+                            {/* Display future trips */}
+                            {jsonData.map((trip, tripIndex) => {
+                                // Extract departure and arrival info
+                                const departureInfos = trip.filter(info => info.startsWith('From:'));
+                                const arrivalInfos = trip.filter(info => info.startsWith('To:'));
+                                
+                                // Get the first departure and last arrival for multi-leg journeys
+                                const firstDepartureInfo = departureInfos[0]?.split('Departing at:');
+                                const lastArrivalInfo = arrivalInfos[arrivalInfos.length - 1]?.split('Arriving at');
 
-                        return (
-                            <div
-                                key={tripIndex}
-                                id={`trip-${tripIndex}`}
-                                className={`${styles.tripOption} ${expandedTrip === tripIndex ? styles.expanded : ''} ${tripIndex === nextTripIndex ? styles.nextTrip : ''}`}
-                                ref={tripIndex === nextTripIndex ? nextTripRef : null}
-                                onClick={() => handleTripClick(tripIndex)}
-                                role="button"
-                                tabIndex={0}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter' || e.key === ' ') {
-                                        handleTripClick(tripIndex);
-                                    }
-                                }}
-                            >
-                                <div className={styles.tripSummary}>
-                                    <div 
-                                        id={`trip-main-${tripIndex}`}
-                                        className={styles.tripMainInfo}
-                                    >
-                                        <div className={styles.stationContainer}>
-                                            <div className={styles.stationName}>
-                                                {formatStationName(firstDepartureInfo?.[0])}
-                                            </div>
-                                            <div className={styles.stationTime}>
-                                                {firstDepartureInfo && `${formatTimeWithDate(firstDepartureInfo[1])}`}
-                                                {!isArr && firstDepartureInfo?.[1] && time && timePreference !== 'current' && (() => {
-                                                    const departureTime = firstDepartureInfo[1];
-                                                    if (!departureTime) return null;
-                                                    const diff = calculateTimeDifference(departureTime, time);
-                                                    if (diff === null) return null;
-                                                    return (
-                                                        <div className={styles.timeDifference}>
-                                                            ({formatTime(Math.abs(diff))} after requested time)
-                                                        </div>
-                                                    );
-                                                })()}
-                                            </div>
-                                        </div>
-                                        <div className={`${styles.stationContainer} ${styles.right}`}>
-                                            <div className={styles.stationName}>
-                                                {formatStationName(lastArrivalInfo?.[0])}
-                                            </div>
-                                            <div className={styles.stationTime}>
-                                                {lastArrivalInfo && `${formatTimeWithDate(lastArrivalInfo[1])}`}
-                                                {isArr && lastArrivalInfo?.[1] && time && timePreference !== 'current' && (() => {
-                                                    const arrivalTime = lastArrivalInfo[1];
-                                                    if (!arrivalTime) return null;
-                                                    const diff = calculateTimeDifference(arrivalTime, time);
-                                                    if (diff === null) return null;
-                                                    return (
-                                                        <div className={styles.timeDifference}>
-                                                            ({formatTime(Math.abs(diff))} before requested time)
-                                                        </div>
-                                                    );
-                                                })()}
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div className={styles.rightSection}>
-                                        {hasTrainLineChanges(trip) && (
-                                            <div className={styles.legsInfo}>
-                                                {`${getNumberOfTrainLineChanges(trip)} train line change(s)`}
-                                            </div>
-                                        )}
-                                        <div className={`${styles.tripStatusSection} ${
-                                            firstDepartureInfo?.[1] ? (() => {
-                                                const [datePart, timePart] = firstDepartureInfo[1].trim().split(', ');
-                                                if (!datePart || !timePart) return styles.tripStatusUpcoming;
-                                                const [day, month, year] = datePart.split('/').map(Number);
-                                                const [hours, minutes] = timePart.split(':').map(Number);
-                                                const departureTime = new Date(year, month - 1, day, hours, minutes);
-                                                return departureTime < new Date() ? styles.tripStatusDeparted : styles.tripStatusUpcoming;
-                                            })() : styles.tripStatusUpcoming
-                                        }`}>
-                                            <div className={styles.tripInfoBox}>
-                                                {(() => {
-                                                    const timeUntil = firstDepartureInfo?.[1] ? calculateTimeUntilDeparture(firstDepartureInfo[1]) : null;
-                                                    return (
-                                                        <>
-                                                            {timeUntil && (
-                                                                <div className={styles.timeUntilDeparture}>
-                                                                    {timeUntil}
-                                                                </div>
-                                                            )}
-                                                        </>
-                                                    );
-                                                })()}
-                                            </div>
-                                            <div className={styles.expandIcon}>
-                                                ▼
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className={`${styles.tripDetails} ${expandedTrip === tripIndex ? styles.visible : ''}`}>
-                                    <div className={styles.tripExtendedInfo}>
-                                        <div className={styles.transportLines}>
-                                            {trip
-                                                .filter(info => info.startsWith('On:'))
-                                                .map((transportInfo, index) => {
-                                                    const trainLine = extractTrainLine(transportInfo.replace('On: ', ''));
-                                                    const color = getTrainLineColor(trainLine);
-
-                                                    return (
-                                                        <div key={index} className={styles.transportLine}>
-                                                            <div
-                                                                className={styles.trainLineIndicator}
-                                                                style={{ backgroundColor: color }}
-                                                            />
-                                                            <span>{trainLine}</span>
-                                                        </div>
-                                                    );
-                                                })}
-                                        </div>
-                                        <div className={styles.totalTripDuration}>
-                                            <i className="fas fa-clock"></i>
-                                            <span>Total Duration: {calculateTotalDuration(trip)}</span>
-                                        </div>
-                                    </div>
-                                    <div className={styles.tripLegs}>
-                                        {(() => {
-                                            // Group the trip items into legs
-                                            const legs: string[][] = [];
-                                            let currentLeg: string[] = [];
-                                            
-                                            trip.forEach((info) => {
-                                                if (info.startsWith('From:') && currentLeg.length > 0) {
-                                                    legs.push([...currentLeg]);
-                                                    currentLeg = [];
-                                                }
-                                                currentLeg.push(info);
-                                            });
-                                            if (currentLeg.length > 0) {
-                                                legs.push(currentLeg);
+                                return (
+                                    <div
+                                        key={tripIndex}
+                                        id={`trip-${tripIndex}`}
+                                        className={`${styles.tripOption} ${expandedTrip === tripIndex ? styles.expanded : ''} ${tripIndex === nextTripIndex ? styles.nextTrip : ''}`}
+                                        ref={tripIndex === nextTripIndex ? nextTripRef : null}
+                                        onClick={() => handleTripClick(tripIndex)}
+                                        role="button"
+                                        tabIndex={0}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                handleTripClick(tripIndex);
                                             }
-
-                                            return legs.map((leg, legIndex) => (
-                                                <Fragment key={legIndex}>
-                                                    <div 
-                                                        className={styles.tripLeg}
-                                                        style={{ '--line-color': getTrainLineColor(extractTrainLine(leg.find(info => info.startsWith('On:'))?.replace('On: ', '') || '')) } as React.CSSProperties}
-                                                    >
-                                                        {leg.map((info, infoIndex) => {
-                                                            if (info.startsWith('On:')) return null;
-                                                            
-                                                            const formattedInfo = formatTripInfo(info);
-                                                            if (!formattedInfo) return null;
-
-                                                            const isLastItem = infoIndex === leg.length - 1;
+                                        }}
+                                    >
+                                        <div className={styles.tripSummary}>
+                                            <div 
+                                                id={`trip-main-${tripIndex}`}
+                                                className={styles.tripMainInfo}
+                                            >
+                                                <div className={styles.stationContainer}>
+                                                    <div className={styles.stationName}>
+                                                        {formatStationName(firstDepartureInfo?.[0])}
+                                                    </div>
+                                                    <div className={styles.stationTime}>
+                                                        {firstDepartureInfo && `${formatTimeWithDate(firstDepartureInfo[1])}`}
+                                                        {!isArr && firstDepartureInfo?.[1] && time && timePreference !== 'current' && (() => {
+                                                            const departureTime = firstDepartureInfo[1];
+                                                            if (!departureTime) return null;
+                                                            const diff = calculateTimeDifference(departureTime, time);
+                                                            if (diff === null) return null;
                                                             return (
-                                                                <div key={infoIndex} className={styles.tripItem}>
-                                                                    {formattedInfo}
-                                                                    {isLastItem && (
-                                                                        <div className={styles.trainLine}>
-                                                                            {extractTrainLine(leg.find(info => info.startsWith('On:'))?.replace('On: ', '') || '')}
+                                                                <div className={styles.timeDifference}>
+                                                                    ({formatTime(Math.abs(diff))} after requested time)
+                                                                </div>
+                                                            );
+                                                        })()}
+                                                    </div>
+                                                </div>
+                                                <div className={`${styles.stationContainer} ${styles.right}`}>
+                                                    <div className={styles.stationName}>
+                                                        {formatStationName(lastArrivalInfo?.[0])}
+                                                    </div>
+                                                    <div className={styles.stationTime}>
+                                                        {lastArrivalInfo && `${formatTimeWithDate(lastArrivalInfo[1])}`}
+                                                        {isArr && lastArrivalInfo?.[1] && time && timePreference !== 'current' && (() => {
+                                                            const arrivalTime = lastArrivalInfo[1];
+                                                            if (!arrivalTime) return null;
+                                                            const diff = calculateTimeDifference(arrivalTime, time);
+                                                            if (diff === null) return null;
+                                                            return (
+                                                                <div className={styles.timeDifference}>
+                                                                    ({formatTime(Math.abs(diff))} before requested time)
+                                                                </div>
+                                                            );
+                                                        })()}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div className={styles.rightSection}>
+                                                {hasTrainLineChanges(trip) && (
+                                                    <div className={styles.legsInfo}>
+                                                        {`${getNumberOfTrainLineChanges(trip)} train line change(s)`}
+                                                    </div>
+                                                )}
+                                                <div className={`${styles.tripStatusSection} ${
+                                                    firstDepartureInfo?.[1] ? (() => {
+                                                        const [datePart, timePart] = firstDepartureInfo[1].trim().split(', ');
+                                                        if (!datePart || !timePart) return styles.tripStatusUpcoming;
+                                                        const [day, month, year] = datePart.split('/').map(Number);
+                                                        const [hours, minutes] = timePart.split(':').map(Number);
+                                                        const departureTime = new Date(year, month - 1, day, hours, minutes);
+                                                        return departureTime < new Date() ? styles.tripStatusDeparted : styles.tripStatusUpcoming;
+                                                    })() : styles.tripStatusUpcoming
+                                                }`}>
+                                                    <div className={styles.tripInfoBox}>
+                                                        {(() => {
+                                                            const timeUntil = firstDepartureInfo?.[1] ? calculateTimeUntilDeparture(firstDepartureInfo[1]) : null;
+                                                            return (
+                                                                <>
+                                                                    {timeUntil && (
+                                                                        <div className={styles.timeUntilDeparture}>
+                                                                            {timeUntil}
                                                                         </div>
                                                                     )}
+                                                                </>
+                                                            );
+                                                        })()}
+                                                    </div>
+                                                    <div className={styles.expandIcon}>
+                                                        ▼
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div className={`${styles.tripDetails} ${expandedTrip === tripIndex ? styles.visible : ''}`}>
+                                            <div className={styles.tripExtendedInfo}>
+                                                <div className={styles.transportLines}>
+                                                    {trip
+                                                        .filter(info => info.startsWith('On:'))
+                                                        .map((transportInfo, index) => {
+                                                            const trainLine = extractTrainLine(transportInfo.replace('On: ', ''));
+                                                            const color = getTrainLineColor(trainLine);
+
+                                                            return (
+                                                                <div key={index} className={styles.transportLine}>
+                                                                    <div
+                                                                        className={styles.trainLineIndicator}
+                                                                        style={{ backgroundColor: color }}
+                                                                    />
+                                                                    <span>{trainLine}</span>
                                                                 </div>
                                                             );
                                                         })}
-                                                    </div>
-                                                    {legIndex < legs.length - 1 && (
-                                                        <div className={styles.tripLegSeparator}>
-                                                            <div className={styles.tripLegDivider} />
-                                                            {(() => {
-                                                                const waitTime = calculateWaitingTime(leg, legs[legIndex + 1]);
-                                                                return waitTime && (
-                                                                    <div className={styles.waitTimeIndicator}>
-                                                                        {formatTime(waitTime, true)}
-                                                                    </div>
-                                                                );
-                                                            })()}
-                                                            <div className={styles.tripLegDivider} />
-                                                        </div>
-                                                    )}
-                                                </Fragment>
-                                            ));
-                                        })()}
+                                                </div>
+                                                <div className={styles.totalTripDuration}>
+                                                    <i className="fas fa-clock"></i>
+                                                    <span>Total Duration: {calculateTotalDuration(trip)}</span>
+                                                </div>
+                                            </div>
+                                            <div className={styles.tripLegs}>
+                                                {(() => {
+                                                    // Group the trip items into legs
+                                                    const legs: string[][] = [];
+                                                    let currentLeg: string[] = [];
+                                                    
+                                                    trip.forEach((info) => {
+                                                        if (info.startsWith('From:') && currentLeg.length > 0) {
+                                                            legs.push([...currentLeg]);
+                                                            currentLeg = [];
+                                                        }
+                                                        currentLeg.push(info);
+                                                    });
+                                                    if (currentLeg.length > 0) {
+                                                        legs.push(currentLeg);
+                                                    }
+
+                                                    return legs.map((leg, legIndex) => (
+                                                        <Fragment key={legIndex}>
+                                                            <div 
+                                                                className={styles.tripLeg}
+                                                                style={{ '--line-color': getTrainLineColor(extractTrainLine(leg.find(info => info.startsWith('On:'))?.replace('On: ', '') || '')) } as React.CSSProperties}
+                                                            >
+                                                                {leg.map((info, infoIndex) => {
+                                                                    if (info.startsWith('On:')) return null;
+                                                                    
+                                                                    const formattedInfo = formatTripInfo(info);
+                                                                    if (!formattedInfo) return null;
+
+                                                                    const isLastItem = infoIndex === leg.length - 1;
+                                                                    return (
+                                                                        <div key={infoIndex} className={styles.tripItem}>
+                                                                            {formattedInfo}
+                                                                            {isLastItem && (
+                                                                                <div className={styles.trainLine}>
+                                                                                    {extractTrainLine(leg.find(info => info.startsWith('On:'))?.replace('On: ', '') || '')}
+                                                                                </div>
+                                                                            )}
+                                                                        </div>
+                                                                    );
+                                                                })}
+                                                            </div>
+                                                            {legIndex < legs.length - 1 && (
+                                                                <div className={styles.tripLegSeparator}>
+                                                                    <div className={styles.tripLegDivider} />
+                                                                    {(() => {
+                                                                        const waitTime = calculateWaitingTime(leg, legs[legIndex + 1]);
+                                                                        return waitTime && (
+                                                                            <div className={styles.waitTimeIndicator}>
+                                                                                {formatTime(waitTime, true)}
+                                                                            </div>
+                                                                        );
+                                                                    })()}
+                                                                    <div className={styles.tripLegDivider} />
+                                                                </div>
+                                                            )}
+                                                        </Fragment>
+                                                    ));
+                                                })()}
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            </main>
-            <Footer />
-            <ScrollToTop />
+                                );
+                            })}
+                        </div>
+                    </main>
+                    <Footer />
+                    <ScrollToTop />
+                </>
+            )}
         </div>
     );
 }

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -6,6 +6,7 @@ import { FetchtripData } from '../api/apiCalls';
 import { getStationNameFromId } from '@/utils/getData';
 import trainLineColours from '@/config/trainLineColours';
 import styles from './tripPlanning.module.css';
+import headerStyles from '@/components/Header.module.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import ScrollToTop from '@/components/ScrollToTop';
@@ -27,6 +28,13 @@ export default function Home() {
     const fromName = getStationNameFromId(fromStation as string);
     const toName = getStationNameFromId(toStation as string);
     const [expandedTrip, setExpandedTrip] = useState<number | null>(null);
+
+    // Function to simplify station names by removing "Station" suffix
+    const simplifyStationName = (name: any): string => {
+        if (!name) return '';
+        const nameStr = String(name);
+        return nameStr.replace(' Station', '');
+    };
 
     const nextTripRef = useRef<HTMLDivElement>(null);
     const initialScrollDone = useRef(false);
@@ -500,6 +508,7 @@ export default function Home() {
         // Get platform if it exists
         const platform = parts.find(part => part.startsWith('Platform'));
 
+        // For mobile display, we want them on one line
         return platform ? `${mainName}, ${platform}` : mainName;
     };
 
@@ -672,14 +681,14 @@ export default function Home() {
             setTimeout(() => {
                 const tripElement = document.getElementById(`trip-main-${tripIndex}`);
                 if (tripElement) {
-                    const offset = 170;
+                    const offset = 180;
                     const elementTop = tripElement.getBoundingClientRect().top + window.scrollY;
                     window.scrollTo({
                         top: elementTop - offset,
                         behavior: 'smooth'
                     });
                 }
-            }, 300);
+            }, 400);
         }, 300);
     };
 
@@ -706,7 +715,17 @@ export default function Home() {
                 <Loading message="Finding your trips..." />
             ) : (
                 <>
-                    <Header title={`Trip From ${fromName} to ${toName}!`} text='Map' link='/mapInput' />
+                    <Header 
+                        title={
+                            <div className={headerStyles.verticalTitle}>
+                                <span className={headerStyles.stationName}>{simplifyStationName(fromName)}</span>
+                                <span className={headerStyles.arrow}>↓</span>
+                                <span className={headerStyles.stationName}>{simplifyStationName(toName)}</span>
+                            </div>
+                        } 
+                        text='Map' 
+                        link='/mapInput' 
+                    />
                     <SubHeader
                         timeInfo={getTimePreferenceText()}
                         onClosestTrip={scrollToClosestTrip}
@@ -789,7 +808,7 @@ export default function Home() {
                                             <div className={styles.rightSection}>
                                                 {hasTrainLineChanges(trip) && (
                                                     <div className={styles.legsInfo}>
-                                                        {`${getNumberOfTrainLineChanges(trip)} train line change(s)`}
+                                                        {`${getNumberOfTrainLineChanges(trip)} swap(s)`}
                                                     </div>
                                                 )}
                                                 <div className={`${styles.tripStatusSection} ${firstDepartureInfo?.[1] ? (() => {
@@ -815,7 +834,13 @@ export default function Home() {
                                                             );
                                                         })()}
                                                     </div>
-                                                    <div className={styles.expandIcon}>
+                                                    <div
+                                                        onClick={(e: React.MouseEvent) => {
+                                                            e.stopPropagation();
+                                                            handleTripClick(tripIndex);
+                                                        }}
+                                                        className={styles.expandIcon}
+                                                    >
                                                         ▼
                                                     </div>
                                                 </div>

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -458,9 +458,8 @@ export default function Home() {
         fetchData();
     }, [fromStation, toStation, time, isArr, date, timeValue]);
 
-    // Effect to scroll to next trip when data loads
     useEffect(() => {
-        const scrollToNextTrip = () => {
+        const scrollToNextTripInitial = () => {
             if (nextTripRef.current && nextTripIndex !== null && !initialScrollDone.current) {
                 const element = nextTripRef.current;
                 const headerOffset = 140;
@@ -477,68 +476,30 @@ export default function Home() {
         };
 
         // Initial scroll attempt
-        scrollToNextTrip();
+        scrollToNextTripInitial();
         
-        // Backup scroll attempt after a delay
-        const timeoutId = setTimeout(scrollToNextTrip, 500);
+        // Backup scroll attempt after a delay in case the first attempt fails
+        const timeoutId = setTimeout(scrollToNextTripInitial, 500);
         
         return () => clearTimeout(timeoutId);
     }, [nextTripIndex, jsonData]);
 
-    // Function to get the number of train line changes
-    const getNumberOfTrainLineChanges = (trip: string[]) => {
-        // Number of train line changes is one less than the number of legs
-        const numberOfLegs = trip.filter((info) => info.startsWith('From:')).length;
-        return numberOfLegs > 1 ? numberOfLegs - 1 : 0;
-    };
+    // Function to format station name consistently
+    const formatStationName = (stationInfo: string | undefined) => {
+        if (!stationInfo) return '';
+        const parts = stationInfo.split(', ');
+        if (parts.length < 2) return stationInfo;
 
-    // Function to check if the trip has train line changes
-    const hasTrainLineChanges = (trip: string[]) => {
-        return getNumberOfTrainLineChanges(trip) > 0;
-    };
+        // Get main station name without "Station" and suburb, and remove From/To prefix
+        const mainName = parts[0]
+            .replace(' Station', '')
+            .replace('From: ', '')
+            .replace('To: ', '');
+        
+        // Get platform if it exists
+        const platform = parts.find(part => part.startsWith('Platform'));
 
-    // Function to extract train line info
-    const extractTrainLine = (info: string) => {
-        const match = info.match(/Sydney Trains Network\s+(.+)/);
-        return match ? match[1] : info;
-    };
-
-    // Function to get train line color
-    const getTrainLineColor = (trainLine: string) => {
-        const color = Object.entries(trainLineColours).find(([key]) =>
-            trainLine.includes(key)
-        );
-        return color ? color[1] : '#6f818d';
-    };
-
-    const handleTripClick = (tripIndex: number) => {
-        // If clicking the same trip, just close it
-        if (expandedTrip === tripIndex) {
-            setExpandedTrip(null);
-            return;
-        }
-
-        // Step 1: Close any open trip
-        setExpandedTrip(null);
-
-        // Step 2: Wait for the closing animation
-        setTimeout(() => {
-            // Step 3: Open the new trip
-            setExpandedTrip(tripIndex);
-
-            // Step 4: Wait for the opening animation and DOM update
-            setTimeout(() => {
-                const tripElement = document.getElementById(`trip-main-${tripIndex}`);
-                if (tripElement) {
-                    const offset = 170;
-                    const elementTop = tripElement.getBoundingClientRect().top + window.scrollY;
-                    window.scrollTo({
-                        top: elementTop - offset,
-                        behavior: 'smooth'
-                    });
-                }
-            }, 200); // Longer wait to ensure the animation is complete
-        }, 300); // Longer wait to ensure the closing is complete
+        return platform ? `${mainName}, ${platform}` : mainName;
     };
 
     // Function to format trip information
@@ -595,22 +556,30 @@ export default function Home() {
         return null;
     };
 
-    // Function to format station name consistently
-    const formatStationName = (stationInfo: string | undefined) => {
-        if (!stationInfo) return '';
-        const parts = stationInfo.split(', ');
-        if (parts.length < 2) return stationInfo;
+    // Function to get the number of train line changes
+    const getNumberOfTrainLineChanges = (trip: string[]) => {
+        // Number of train line changes is one less than the number of legs
+        const numberOfLegs = trip.filter((info) => info.startsWith('From:')).length;
+        return numberOfLegs > 1 ? numberOfLegs - 1 : 0;
+    };
 
-        // Get main station name without "Station" and suburb, and remove From/To prefix
-        const mainName = parts[0]
-            .replace(' Station', '')
-            .replace('From: ', '')
-            .replace('To: ', '');
-        
-        // Get platform if it exists
-        const platform = parts.find(part => part.startsWith('Platform'));
+    // Function to check if the trip has train line changes
+    const hasTrainLineChanges = (trip: string[]) => {
+        return getNumberOfTrainLineChanges(trip) > 0;
+    };
 
-        return platform ? `${mainName}, ${platform}` : mainName;
+    // Function to extract train line info
+    const extractTrainLine = (info: string) => {
+        const match = info.match(/Sydney Trains Network\s+(.+)/);
+        return match ? match[1] : info;
+    };
+
+    // Function to get train line color
+    const getTrainLineColor = (trainLine: string) => {
+        const color = Object.entries(trainLineColours).find(([key]) =>
+            trainLine.includes(key)
+        );
+        return color ? color[1] : '#6f818d';
     };
 
     // Function to calculate waiting time between legs
@@ -683,10 +652,59 @@ export default function Home() {
         return formatTime(totalDuration);
     };
 
+    const handleTripClick = (tripIndex: number) => {
+        // If clicking the same trip, just close it
+        if (expandedTrip === tripIndex) {
+            setExpandedTrip(null);
+            return;
+        }
+
+        // Step 1: Close any open trip
+        setExpandedTrip(null);
+
+        // Step 2: Wait for the closing animation
+        setTimeout(() => {
+            // Step 3: Open the new trip
+            setExpandedTrip(tripIndex);
+
+            // Step 4: Wait for the opening animation and DOM update
+            setTimeout(() => {
+                const tripElement = document.getElementById(`trip-main-${tripIndex}`);
+                if (tripElement) {
+                    const offset = 170;
+                    const elementTop = tripElement.getBoundingClientRect().top + window.scrollY;
+                    window.scrollTo({
+                        top: elementTop - offset,
+                        behavior: 'smooth'
+                    });
+                }
+            }, 300);
+        }, 300);
+    };
+
+    // Function to scroll to closest trip
+    const scrollToClosestTrip = () => {
+        if (nextTripRef.current && nextTripIndex !== null) {
+            const element = nextTripRef.current;
+            const headerOffset = 140;
+            const elementPosition = element.getBoundingClientRect().top;
+            const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+
+            window.scrollTo({
+                top: offsetPosition,
+                behavior: 'smooth'
+            });
+        }
+    };
+
     return (
         <div className={styles.page}>
             <Header title={`Trip From ${fromName} to ${toName}!`} />
-            <SubHeader timeInfo={getTimePreferenceText()} />
+            <SubHeader 
+                timeInfo={getTimePreferenceText()} 
+                onClosestTrip={scrollToClosestTrip}
+                hasClosestTrip={nextTripIndex !== null}
+            />
             <main className={styles.main}>
                 <div className={styles.tripContent}>
                     <div className={styles.tripDetails}>

--- a/ripview/src/app/tripPlanning/page.tsx
+++ b/ripview/src/app/tripPlanning/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
         const updateTimeAndTrips = () => {
             const now = new Date();
             setCurrentTime(now);
-            
+
             // Find the next upcoming trip based on current time
             if (jsonData.length > 0 && jsonData[0]?.[0] !== 'Loading...') {
                 const nextIndex = jsonData.findIndex(trip => {
@@ -59,15 +59,15 @@ export default function Home() {
                     if (!departureInfo) return false;
                     const timeMatch = departureInfo.match(/From: .+\. Departing at: (\d{2}\/\d{2}\/\d{4}, \d{2}:\d{2})/);
                     if (!timeMatch) return false;
-                    
+
                     // Parse date components
                     const [datePart, timePart] = timeMatch[1].split(', ');
                     const [day, month, year] = datePart.split('/').map(Number);
                     const [hours, minutes] = timePart.split(':').map(Number);
-                    
+
                     // Create date with correct components
                     const departureTime = new Date(year, month - 1, day, hours, minutes);
-                    
+
                     return departureTime.getTime() > now.getTime();
                 });
 
@@ -85,10 +85,10 @@ export default function Home() {
         // Set timeout to sync with the start of the next minute
         const initialTimeout = setTimeout(() => {
             updateTimeAndTrips();
-            
+
             // Then set interval to run every minute, exactly on the minute
             const interval = setInterval(updateTimeAndTrips, 60000);
-            
+
             // Cleanup interval on component unmount
             return () => clearInterval(interval);
         }, msUntilNextMinute);
@@ -100,13 +100,13 @@ export default function Home() {
     // Unified time formatting function that handles all cases
     const formatTime = (minutes: number, includeWait: boolean = false) => {
         const absMins = Math.abs(minutes);
-        
+
         if (absMins < 60) {
             return `${absMins}m${includeWait ? ' wait' : ''}`;
         } else if (absMins < 24 * 60) {
             const hours = Math.floor(absMins / 60);
             const mins = absMins % 60;
-            return hours > 0 
+            return hours > 0
                 ? `${hours}h${mins > 0 ? ` ${mins}m` : ''}${includeWait ? ' wait' : ''}`
                 : `${mins}m${includeWait ? ' wait' : ''}`;
         } else {
@@ -124,14 +124,14 @@ export default function Home() {
         if (dateTimeStr.includes('T')) {
             return new Date(dateTimeStr);
         }
-        
+
         // Handle "DD/MM/YYYY, HH:mm" format
         const [datePart, timePart] = dateTimeStr.split(', ');
         if (!datePart || !timePart) return null;
-        
+
         const [day, month, year] = datePart.split('/').map(Number);
         const [hours, minutes] = timePart.split(':').map(Number);
-        
+
         return new Date(year, month - 1, day, hours, minutes);
     };
 
@@ -157,20 +157,20 @@ export default function Home() {
     const calculateTimeUntilDeparture = (dateTimeStr: string) => {
         const now = new Date();
         const departureTime = parseDateTime(dateTimeStr);
-        
+
         if (!departureTime) return '';
-        
+
         // Calculate difference in minutes
         const diffMs = departureTime.getTime() - now.getTime();
         const diffMins = Math.ceil(diffMs / (1000 * 60));
-        
+
         return formatTime(diffMins);
     };
 
     // Function to format datetime for display
     const formatDateTime = (date: Date) => {
         if (!date || isNaN(date.getTime())) return '';
-        
+
         const isToday = (date: Date) => {
             const today = new Date();
             return date.getDate() === today.getDate() &&
@@ -202,11 +202,11 @@ export default function Home() {
     const getTimePreferenceText = () => {
         if (!time) return '';
         if (timePreference === 'current') {
-            return `Showing trips from current time (${formatDateTime(currentTime)})`;
+            return `Trips from now (${formatDateTime(currentTime)})`;
         } else {
             const targetTime = parseDateTime(time);
-            return targetTime 
-                ? `Showing trips ${isArr ? 'arriving by' : 'departing at'} ${formatDateTime(targetTime)}`
+            return targetTime
+                ? `Trips ${isArr ? 'arriving by' : 'departing at'} ${formatDateTime(targetTime)}`
                 : '';
         }
     };
@@ -271,7 +271,7 @@ export default function Home() {
                     const [arrDay, arrMonth, arrYear] = arrDatePart.split('/').map(Number);
                     const [arrHour, arrMinute] = arrTimePart.split(':').map(Number);
                     const arrivalDateTime = new Date(arrYear, arrMonth - 1, arrDay, arrHour, arrMinute);
-                    
+
                     return !isNaN(arrivalDateTime.getTime()) && arrivalDateTime <= targetDateTime;
                 });
 
@@ -310,7 +310,7 @@ export default function Home() {
                     const seenTripTimes = new Set();
 
                     // Parse the user's selected time
-                    const selectedTime = time && time !== 'current' 
+                    const selectedTime = time && time !== 'current'
                         ? new Date(time.includes('T') ? time : time.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
                         : new Date();
 
@@ -341,10 +341,10 @@ export default function Home() {
                         const departureTime = parseDepartureTime(trip);
                         if (!departureTime) continue;
 
-                        const timeKey = isArr 
-                            ? parseArrivalTime(trip)?.toISOString() 
+                        const timeKey = isArr
+                            ? parseArrivalTime(trip)?.toISOString()
                             : departureTime.toISOString();
-                        
+
                         if (!timeKey) continue;
 
                         // Skip if we've already seen this time
@@ -407,7 +407,7 @@ export default function Home() {
                             if (currentArrival && nextDeparture) {
                                 const arrivalTime = new Date(currentArrival[1].replace(/, /, ' '));
                                 const departureTime = new Date(nextDeparture[1].replace(/, /, ' '));
-                                
+
                                 // If next leg departs before current leg arrives, the sequence is invalid
                                 if (departureTime.getTime() <= arrivalTime.getTime()) {
                                     return false;
@@ -423,7 +423,7 @@ export default function Home() {
                             // Group the trip items into legs
                             const legs: string[][] = [];
                             let currentLeg: string[] = [];
-                            
+
                             trip.forEach((info) => {
                                 if (info.startsWith('From:') && currentLeg.length > 0) {
                                     legs.push([...currentLeg]);
@@ -471,17 +471,17 @@ export default function Home() {
                     top: offsetPosition,
                     behavior: 'smooth'
                 });
-                
+
                 initialScrollDone.current = true;
             }
         };
 
         // Initial scroll attempt
         scrollToNextTripInitial();
-        
+
         // Backup scroll attempt after a delay in case the first attempt fails
         const timeoutId = setTimeout(scrollToNextTripInitial, 500);
-        
+
         return () => clearTimeout(timeoutId);
     }, [nextTripIndex, jsonData]);
 
@@ -496,7 +496,7 @@ export default function Home() {
             .replace(' Station', '')
             .replace('From: ', '')
             .replace('To: ', '');
-        
+
         // Get platform if it exists
         const platform = parts.find(part => part.startsWith('Platform'));
 
@@ -609,7 +609,7 @@ export default function Home() {
         // Group the trip into legs
         const legs: string[][] = [];
         let currentLeg: string[] = [];
-        
+
         trip.forEach((info) => {
             if (info.startsWith('From:') && currentLeg.length > 0) {
                 legs.push([...currentLeg]);
@@ -706,23 +706,23 @@ export default function Home() {
                 <Loading message="Finding your trips..." />
             ) : (
                 <>
-                    <Header title={`Trip From ${fromName} to ${toName}!`} />
-                    <SubHeader 
-                        timeInfo={getTimePreferenceText()} 
+                    <Header title={`Trip From ${fromName} to ${toName}!`} text='Map' link='/mapInput' />
+                    <SubHeader
+                        timeInfo={getTimePreferenceText()}
                         onClosestTrip={scrollToClosestTrip}
                         hasClosestTrip={nextTripIndex !== null}
                     />
                     <main className={styles.main}>
                         <div className={styles.tripContent}>
                             <div className={styles.tripDetails}>
-                                <p>Showing trips for: {getTimePreferenceText()}</p>
+                                <p>{getTimePreferenceText()}</p>
                             </div>
                             {/* Display future trips */}
                             {jsonData.map((trip, tripIndex) => {
                                 // Extract departure and arrival info
                                 const departureInfos = trip.filter(info => info.startsWith('From:'));
                                 const arrivalInfos = trip.filter(info => info.startsWith('To:'));
-                                
+
                                 // Get the first departure and last arrival for multi-leg journeys
                                 const firstDepartureInfo = departureInfos[0]?.split('Departing at:');
                                 const lastArrivalInfo = arrivalInfos[arrivalInfos.length - 1]?.split('Arriving at');
@@ -743,7 +743,7 @@ export default function Home() {
                                         }}
                                     >
                                         <div className={styles.tripSummary}>
-                                            <div 
+                                            <div
                                                 id={`trip-main-${tripIndex}`}
                                                 className={styles.tripMainInfo}
                                             >
@@ -792,8 +792,7 @@ export default function Home() {
                                                         {`${getNumberOfTrainLineChanges(trip)} train line change(s)`}
                                                     </div>
                                                 )}
-                                                <div className={`${styles.tripStatusSection} ${
-                                                    firstDepartureInfo?.[1] ? (() => {
+                                                <div className={`${styles.tripStatusSection} ${firstDepartureInfo?.[1] ? (() => {
                                                         const [datePart, timePart] = firstDepartureInfo[1].trim().split(', ');
                                                         if (!datePart || !timePart) return styles.tripStatusUpcoming;
                                                         const [day, month, year] = datePart.split('/').map(Number);
@@ -801,7 +800,7 @@ export default function Home() {
                                                         const departureTime = new Date(year, month - 1, day, hours, minutes);
                                                         return departureTime < new Date() ? styles.tripStatusDeparted : styles.tripStatusUpcoming;
                                                     })() : styles.tripStatusUpcoming
-                                                }`}>
+                                                    }`}>
                                                     <div className={styles.tripInfoBox}>
                                                         {(() => {
                                                             const timeUntil = firstDepartureInfo?.[1] ? calculateTimeUntilDeparture(firstDepartureInfo[1]) : null;
@@ -852,7 +851,7 @@ export default function Home() {
                                                     // Group the trip items into legs
                                                     const legs: string[][] = [];
                                                     let currentLeg: string[] = [];
-                                                    
+
                                                     trip.forEach((info) => {
                                                         if (info.startsWith('From:') && currentLeg.length > 0) {
                                                             legs.push([...currentLeg]);
@@ -866,13 +865,13 @@ export default function Home() {
 
                                                     return legs.map((leg, legIndex) => (
                                                         <Fragment key={legIndex}>
-                                                            <div 
+                                                            <div
                                                                 className={styles.tripLeg}
                                                                 style={{ '--line-color': getTrainLineColor(extractTrainLine(leg.find(info => info.startsWith('On:'))?.replace('On: ', '') || '')) } as React.CSSProperties}
                                                             >
                                                                 {leg.map((info, infoIndex) => {
                                                                     if (info.startsWith('On:')) return null;
-                                                                    
+
                                                                     const formattedInfo = formatTripInfo(info);
                                                                     if (!formattedInfo) return null;
 

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -300,7 +300,7 @@
     opacity: 0;
     max-height: 0;
     visibility: visible;
-    transition: all 0.3s ease-in-out;
+    transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
     padding: 0 1.25rem;
     margin-top: 0;
     border-top: 1px solid var(--gray-alpha-200);

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -95,8 +95,9 @@
 }
 
 .tripList {
-    list-style-type: none;
+    list-style: none;
     padding: 0;
+    margin: 0;
 }
 
 .tripList li {
@@ -116,10 +117,9 @@
 }
 
 .legDivider {
-    margin: 1.25rem 0;
+    margin: 1rem 0;
     border: none;
-    border-top: 1px solid var(--border-color, #333);
-    opacity: 0.5;
+    border-top: 1px solid var(--gray-alpha-200);
 }
 
 .transportInfo {
@@ -165,6 +165,15 @@
     margin-right: 0.5rem;
 }
 
+.tripDetailItem {
+    padding: 0.5rem 0;
+    font-size: 0.95rem;
+}
+
+.tripDetailItem div {
+    margin: 0.25rem 0;
+}
+
 @media (prefers-color-scheme: dark) {
     .page {
         --gray-rgb: 255, 255, 255;
@@ -193,5 +202,176 @@
 
     .backButton {
         margin: 0.75rem 0 0 1rem;
+    }
+}
+
+.tripSummary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+    gap: 1rem;
+}
+
+.expandIcon {
+    font-size: 0.875rem;
+    transition: transform 0.3s ease;
+}
+
+.tripOption .tripDetails {
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: all 0.3s ease-in-out;
+    margin-top: 0;
+}
+
+.tripOption.expanded .tripDetails {
+    max-height: 1000px; /* Adjust based on your content */
+    opacity: 1;
+    margin-top: 1rem;
+}
+
+.tripOption.expanded .expandIcon {
+    transform: rotate(180deg);
+}
+
+/* Animation for the content */
+.tripDetails.visible {
+    animation: slideDown 0.3s ease-out forwards;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Hover state */
+.tripOption:hover {
+    background-color: var(--gray-alpha-100);
+}
+
+/* Focus state for accessibility */
+.tripOption:focus {
+    outline: 2px solid var(--foreground);
+    outline-offset: 2px;
+}
+
+.tripMainInfo {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    gap: 1rem;
+}
+
+.stationContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.stationContainer.right {
+    text-align: right;
+}
+
+.stationName {
+    font-size: 1rem;
+    font-weight: 500;
+}
+
+.stationTime {
+    font-size: 0.9rem;
+    color: var(--foreground);
+    opacity: 0.8;
+}
+
+.tripTimes {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 500;
+}
+
+.timeArrow {
+    color: var(--foreground);
+    opacity: 0.5;
+}
+
+.stationNames {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--foreground);
+    opacity: 0.8;
+    font-size: 0.9rem;
+}
+
+.stationArrow {
+    opacity: 0.5;
+}
+
+.tripExtendedInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    padding: 1rem;
+    background-color: var(--gray-alpha-100);
+    border-radius: 0.5rem;
+}
+
+.transportLines {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.transportLine {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.95rem;
+    background-color: var(--gray-alpha-200);
+    white-space: nowrap;
+}
+
+.trainLineIndicator {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.totalTripDuration {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--gray-alpha-200);
+}
+
+@media (max-width: 37.5rem) {
+    .tripTimes {
+        font-size: 1rem;
+    }
+
+    .stationNames {
+        font-size: 0.8rem;
+    }
+
+    .tripExtendedInfo {
+        flex-direction: column;
+        gap: 1rem;
     }
 }

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -2,28 +2,30 @@
     --gray-rgb: 0, 0, 0;
     --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
     --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-    display: grid;
-    grid-template-rows: auto 1fr auto;
-    align-items: start;
-    justify-items: center;
-    min-height: 100svh;
-    padding: 0 0 2rem 0;
-    gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    width: 100%;
     font-family: var(--font-geist-sans);
+    padding-top: calc(4rem + 3rem); /* Header + SubHeader height */
 }
 
 .main {
+    flex: 1;
     display: flex;
     flex-direction: column;
     width: 100%;
     max-width: 75rem;
     padding: 1rem 2rem 0 2rem;
+    margin: 0 auto;
+    font-family: var(--font-geist-sans);
 }
 
 .tripContent {
     width: 100%;
     padding: 0 1.25rem;
     margin-bottom: 2rem;
+    flex: 1;
 }
 
 .container {
@@ -161,6 +163,8 @@
 .stationContainer.right {
     align-items: flex-end;
     text-align: right;
+    margin-left: auto;
+    margin-right: 1rem;
 }
 
 .stationName {
@@ -173,11 +177,15 @@
     opacity: 0.8;
 }
 
+.rightSection {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    margin-left: auto;
+    position: relative;
+}
+
 .legsInfo {
-    position: absolute;
-    bottom: -30px;
-    left: 0;
-    margin-top: 3rem;
     padding: 0.375rem 0.75rem;
     background-color: rgba(255, 152, 0, 0.1);
     border: 1px solid rgba(255, 152, 0, 0.2);
@@ -187,11 +195,24 @@
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
+    position: absolute;
+    top: -35px;
+    left: 50%;
+    transform: translateX(-50%);
     white-space: nowrap;
 }
 
 .legsInfo::before {
     content: "⚠️";
+}
+
+.tripStatusSection {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    margin-top: 0.5rem;
 }
 
 .arrivalDifference {
@@ -208,6 +229,9 @@
 }
 
 .tripStatusSection {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
     padding: 0.75rem;
     border-radius: 0.5rem;
     margin-top: 0.5rem;
@@ -340,8 +364,8 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding: 2rem 3rem 2rem 2rem;
-    height: 10rem;
+    padding: 1rem 3rem 1rem 2rem;
+    height: 9rem;
 }
 
 .tripMainInfo {
@@ -349,12 +373,15 @@
     align-items: center;
     gap: 2rem;
     scroll-margin-top: var(--header-offset);
+    flex: 1;
+    margin-right: 1rem;
 }
 
 .rightSection {
     display: flex;
-    align-items: center;
-    gap: 2rem;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
     margin-left: auto;
 }
 
@@ -429,7 +456,7 @@
 }
 
 .nextTrip::before {
-    content: 'Next Trip';
+    content: 'Closest Trip';
     position: absolute;
     top: -10px;
     left: 16px;
@@ -504,5 +531,4 @@
 /* Focus state for accessibility */
 .tripOption:focus {
     outline: 2px solid var(--foreground);
-    outline-offset: 2px;
 }

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -423,7 +423,11 @@
 .waitTimeIndicator {
     color: #666;
     font-size: 0.95em;
-    padding-left: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    margin: 0.5rem 0;
+    background-color: var(--gray-alpha-100);
+    border-radius: 0.25rem;
+    display: inline-block;
 }
 
 .tripLeg {

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -12,6 +12,7 @@
     --gray-rgb: 0, 0, 0;
     --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
     --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
+    --header-offset: 170px;
 
     --button-primary-hover: #383838;
     --button-secondary-hover: #f2f2f2;
@@ -199,43 +200,30 @@
     content: "⚠️";
 }
 
-.tripSummary {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    padding: 2rem;
-    height: 10rem;
-    box-sizing: border-box;
-}
-
-.tripMainInfo {
-    display: flex;
-    align-items: center;
-    gap: 2rem;
-}
-
-.rightSection {
-    display: flex;
-    align-items: center;
-    gap: 2rem;
-    margin-left: auto;
-}
-
 .stationContainer {
     display: flex;
     flex-direction: column;
-    justify-content: center;
     gap: 0.25rem;
     width: 200px;
     height: 64px;
     padding: 0.5rem;
+    box-sizing: border-box;
+    position: relative;
+    justify-content: center;
 }
 
 .stationContainer.right {
     text-align: right;
-    width: 200px;
     padding-right: 1rem;
+}
+
+.stationContainer .legsInfo {
+    position: absolute;
+    top: 100%;
+    left: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+    z-index: 1;
 }
 
 .stationName {
@@ -262,7 +250,6 @@
     border: 1px solid var(--gray-alpha-200);
     border-radius: 0.5rem;
     width: 200px;
-    height: 5rem;
     box-sizing: border-box;
     position: relative;
 }
@@ -272,7 +259,6 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
     height: 100%;
     font-size: 0.9rem;
     width: 100%;
@@ -302,20 +288,24 @@
     transform: translateY(-50%);
     width: 1.5rem;
     height: 1.5rem;
+    transform-origin: center center;
+}
+
+.tripOption.expanded .expandIcon {
+    transform: translateY(-50%) rotate(180deg);
 }
 
 .tripDetails {
     overflow: hidden;
     opacity: 0;
     max-height: 0;
-    transition: max-height 0.5s cubic-bezier(0.4, 0, 0.2, 1),
-                opacity 0.3s ease-in-out,
-                padding 0.3s ease-in-out,
-                margin 0.3s ease-in-out;
+    visibility: visible;
+    transition: all 0.3s ease-in-out;
     padding: 0 1.25rem;
     margin-top: 0;
     border-top: 1px solid var(--gray-alpha-200);
     background-color: var(--gray-alpha-100);
+    transform: translateY(-10px);
 }
 
 .tripDetails.visible {
@@ -323,43 +313,7 @@
     max-height: 2000px;
     padding: 1.25rem;
     margin-top: 1rem;
-}
-
-.tripOption.expanded .tripDetails {
-    max-height: 1000px;
-    opacity: 1;
-    margin-top: 1rem;
-}
-
-.tripOption.expanded .expandIcon {
-    transform: rotate(180deg);
-}
-
-/* Animation for the content */
-.tripDetails.visible {
-    animation: slideDown 0.3s ease-out forwards;
-}
-
-@keyframes slideDown {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-/* Hover state */
-.tripOption:hover {
-    background-color: var(--gray-alpha-100);
-}
-
-/* Focus state for accessibility */
-.tripOption:focus {
-    outline: 2px solid var(--foreground);
-    outline-offset: 2px;
+    transform: translateY(0);
 }
 
 .tripExtendedInfo {
@@ -417,6 +371,30 @@
     box-sizing: border-box;
 }
 
+.tripSummary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 2rem 3rem 2rem 2rem;
+    height: 10rem;
+    box-sizing: border-box;
+}
+
+.tripMainInfo {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    scroll-margin-top: var(--header-offset);
+}
+
+.rightSection {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    margin-left: auto;
+}
+
 @media (prefers-color-scheme: dark) {
     .page {
         --gray-rgb: 255, 255, 255;
@@ -430,6 +408,7 @@
 
 @media (max-width: 37.5rem) {
     .page {
+        --header-offset: 120px;
         padding: 0 0 1rem 0;
     }
 
@@ -459,4 +438,15 @@
         flex-direction: column;
         gap: 1rem;
     }
+}
+
+/* Hover state */
+.tripOption:hover {
+    background-color: var(--gray-alpha-100);
+}
+
+/* Focus state for accessibility */
+.tripOption:focus {
+    outline: 2px solid var(--foreground);
+    outline-offset: 2px;
 }

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -387,11 +387,10 @@
 }
 
 .tripLegDivider {
-    height: 1px;
-    background-color: #e0e0e0;
+    height: 0;  
     margin: 0.5rem 0;
     width: calc(100% - 20px);
-    border: none;
+    border-top: 1px solid #e0e0e0;  
 }
 
 .waitTimeIndicator {
@@ -404,6 +403,43 @@
     position: relative;
     padding-left: 1rem;
     border-left: 0.2rem solid var(--line-color, #e0e0e0);
+}
+
+.sectionTitle {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 1.5rem 0 1rem;
+    color: #333;
+}
+
+.pastJourney {
+    border-left: 4px solid #666;
+    opacity: 0.85;
+}
+
+.tripStatusDeparted {
+    background-color: #666;
+    color: #fff;
+}
+
+.nextTrip {
+    border-left: 4px solid #2196f3;
+    box-shadow: 0 2px 8px rgba(33, 150, 243, 0.1);
+    position: relative;
+}
+
+.nextTrip::before {
+    content: 'Next Trip';
+    position: absolute;
+    top: -10px;
+    left: 16px;
+    background: #2196f3;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    z-index: 1;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -422,7 +458,6 @@
     }
     
     .tripLegDivider {
-        background-color: #404040;
         border-top-color: #404040;
     }
 }

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -110,6 +110,7 @@
 
 .tripItem {
     margin-bottom: 8px;
+    padding: 4px 0;
 }
 
 .tripItem:last-child {
@@ -118,14 +119,15 @@
 
 .trainLine {
     margin-top: 4px;
-    color: #b3b3b3;
+    color: #666;
     font-size: 0.9em;
 }
 
 .legDivider {
+    height: 1px;
+    background-color: #e0e0e0;
     margin: 16px 0;
-    border: none;
-    border-top: 1px solid #e0e0e0;
+    width: 100%;
 }
 
 .timeInfo {
@@ -320,7 +322,7 @@
 
 .trainLine {
     margin-top: 4px;
-    color: #b3b3b3;
+    color: #666;
     font-size: 0.9em;
 }
 
@@ -371,6 +373,39 @@
     padding-bottom: 0.5rem;
 }
 
+/*  */
+.tripLegs {
+    padding: 1rem 0rem;
+
+}
+
+/* The space between the top leg and the wait time indicator */
+.tripLegSeparator {
+    margin: 1rem 0;
+    text-align: left;
+    padding-left: 1rem;
+}
+
+.tripLegDivider {
+    height: 1px;
+    background-color: #e0e0e0;
+    margin: 0.5rem 0;
+    width: calc(100% - 20px);
+    border: none;
+}
+
+.waitTimeIndicator {
+    color: #666;
+    font-size: 0.95em;
+    padding-left: 0.25rem;
+}
+
+.tripLeg {
+    position: relative;
+    padding-left: 1rem;
+    border-left: 0.2rem solid var(--line-color, #e0e0e0);
+}
+
 @media (prefers-color-scheme: dark) {
     .page {
         --gray-rgb: 255, 255, 255;
@@ -379,6 +414,16 @@
 
         --button-primary-hover: #ccc;
         --button-secondary-hover: #1a1a1a;
+    }
+
+    .waitTimeIndicator,
+    .trainLine {
+        color: #ccc;
+    }
+    
+    .tripLegDivider {
+        background-color: #404040;
+        border-top-color: #404040;
     }
 }
 

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -100,26 +100,56 @@
     margin: 0;
 }
 
-.tripList li {
-    margin: 0.625rem 0;
+.legGroup {
+    position: relative;
+    margin-bottom: 16px;
 }
 
-.tripList li div {
-    margin: 0.3125rem 0;
-    line-height: 1.5;
+.legGroup:last-child {
+    margin-bottom: 0;
+}
+
+.legContent {
+    position: relative;
+    padding-left: 20px;
+}
+
+.legContent::before {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    border-radius: 1.5px;
+    background-color: var(--line-color, #6f818d);
+}
+
+.tripItem {
+    margin-bottom: 8px;
+}
+
+.tripItem:last-child {
+    margin-bottom: 0;
+}
+
+.trainLine {
+    margin-top: 4px;
+    color: #b3b3b3;
+    font-size: 0.9em;
+}
+
+.legDivider {
+    margin: 16px 0;
+    border: none;
+    border-top: 1px solid #e0e0e0;
 }
 
 .timeInfo {
     color: var(--foreground);
     opacity: 0.8;
     font-size: 0.95rem;
-    margin-left: 1.25rem;
-}
-
-.legDivider {
-    margin: 1rem 0;
-    border: none;
-    border-top: 1px solid var(--gray-alpha-200);
+    padding-top: 0.5rem;
 }
 
 .transportInfo {
@@ -350,6 +380,12 @@
     height: 1rem;
     border-radius: 50%;
     flex-shrink: 0;
+}
+
+.trainLine {
+    margin-top: 4px;
+    color: #b3b3b3;
+    font-size: 0.9em;
 }
 
 .totalTripDuration {

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -211,7 +211,7 @@
     margin-top: 0.5rem;
     background-color: var(--gray-alpha-100);
     border: 1px solid var(--gray-alpha-200);
-    width: 200px;
+    width: 6.875rem;
     position: relative;
 }
 

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -24,6 +24,7 @@
     padding: 0 0 2rem 0;
     gap: 1rem;
     font-family: var(--font-geist-sans);
+    box-sizing: border-box;
 }
 
 .main {
@@ -32,12 +33,14 @@
     width: 100%;
     max-width: 75rem;
     padding: 1rem 2rem 0 2rem;
+    box-sizing: border-box;
 }
 
 .tripContent {
     width: 100%;
     padding: 0 1.25rem;
     margin-bottom: 2rem;
+    box-sizing: border-box;
 }
 
 .container {
@@ -47,6 +50,7 @@
     margin: 0 auto;
     font-family: inherit;
     padding-top: 2rem;
+    box-sizing: border-box;
 }
 
 .backButton {
@@ -57,6 +61,7 @@
     color: var(--foreground);
     cursor: pointer;
     transition: all 0.3s ease;
+    box-sizing: border-box;
 }
 
 .backButton:hover {
@@ -69,17 +74,18 @@
     font-weight: 500;
     text-align: center;
     padding-bottom: 1rem;
+    box-sizing: border-box;
 }
 
 .tripOption {
     margin-bottom: 1.25rem;
-    padding: 1.25rem;
     border: 1px solid var(--gray-alpha-200);
     border-radius: 0.3125rem;
     background-color: rgba(31, 31, 31, 0.1);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     box-shadow: 0 2px 12px rgba(var(--gray-rgb), 0.1);
     cursor: pointer;
+    box-sizing: border-box;
 }
 
 .tripOption:hover {
@@ -92,17 +98,20 @@
     margin-bottom: 0.9375rem;
     font-size: 1.2rem;
     font-weight: 500;
+    box-sizing: border-box;
 }
 
 .tripList {
     list-style: none;
-    padding: 0;
+    padding: 1rem;
     margin: 0;
+    box-sizing: border-box;
 }
 
 .legGroup {
     position: relative;
     margin-bottom: 16px;
+    box-sizing: border-box;
 }
 
 .legGroup:last-child {
@@ -112,6 +121,7 @@
 .legContent {
     position: relative;
     padding-left: 20px;
+    box-sizing: border-box;
 }
 
 .legContent::before {
@@ -127,6 +137,7 @@
 
 .tripItem {
     margin-bottom: 8px;
+    box-sizing: border-box;
 }
 
 .tripItem:last-child {
@@ -137,12 +148,14 @@
     margin-top: 4px;
     color: #b3b3b3;
     font-size: 0.9em;
+    box-sizing: border-box;
 }
 
 .legDivider {
     margin: 16px 0;
     border: none;
     border-top: 1px solid #e0e0e0;
+    box-sizing: border-box;
 }
 
 .timeInfo {
@@ -150,22 +163,25 @@
     opacity: 0.8;
     font-size: 0.95rem;
     padding-top: 0.5rem;
+    box-sizing: border-box;
 }
 
 .transportInfo {
     margin-top: 0.625rem;
     font-weight: 500;
+    box-sizing: border-box;
 }
 
 .durationInfo {
     color: var(--foreground);
     opacity: 0.8;
     font-size: 0.9rem;
+    box-sizing: border-box;
 }
 
 .legsInfo {
-    margin: -0.625rem 0 0.9375rem 0;
-    padding: 0.375rem 0.75rem 0.375rem 0.5rem;
+    margin: 0;
+    padding: 0.375rem 0.75rem;
     background-color: rgba(255, 152, 0, 0.1);
     border: 1px solid rgba(255, 152, 0, 0.2);
     border-radius: 0.25rem;
@@ -174,90 +190,143 @@
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
+    white-space: nowrap;
+    box-sizing: border-box;
+    width: fit-content;
 }
 
 .legsInfo::before {
     content: "⚠️";
 }
 
-.tripDetails {
-    margin: -0.5rem 0 1.5rem 0;
-    padding: 0.75rem 1rem;
-    background-color: var(--gray-alpha-100);
-    border: 1px solid var(--gray-alpha-200);
-    border-radius: 0.5rem;
-    font-size: 0.95rem;
-    color: var(--foreground);
-}
-
-.tripDetails p::before {
-    content: "🕒";
-    margin-right: 0.5rem;
-}
-
-.tripDetailItem {
-    padding: 0.5rem 0;
-    font-size: 0.95rem;
-}
-
-.tripDetailItem div {
-    margin: 0.25rem 0;
-}
-
-@media (prefers-color-scheme: dark) {
-    .page {
-        --gray-rgb: 255, 255, 255;
-        --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
-        --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
-
-        --button-primary-hover: #ccc;
-        --button-secondary-hover: #1a1a1a;
-    }
-}
-
-@media (max-width: 37.5rem) {
-    .page {
-        padding: 0 0 1rem 0;
-    }
-
-    .main {
-        align-items: center;
-        padding: 0 1rem;
-        margin-bottom: 1rem;
-    }
-
-    .tripContent {
-        margin-bottom: 1rem;
-    }
-
-    .backButton {
-        margin: 0.75rem 0 0 1rem;
-    }
-}
-
 .tripSummary {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    width: 100%;
+    padding: 2rem;
+    height: 10rem;
+    box-sizing: border-box;
+}
+
+.tripMainInfo {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+}
+
+.rightSection {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    margin-left: auto;
+}
+
+.stationContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.25rem;
+    width: 200px;
+    height: 64px;
+    padding: 0.5rem;
+}
+
+.stationContainer.right {
+    text-align: right;
+    width: 200px;
+    padding-right: 1rem;
+}
+
+.stationName {
+    font-size: 1rem;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.stationTime {
+    font-size: 0.9rem;
+    color: var(--foreground);
+    opacity: 0.8;
+    white-space: nowrap;
+}
+
+.tripStatusSection {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 1rem;
-    gap: 1rem;
+    background-color: var(--gray-alpha-100);
+    border: 1px solid var(--gray-alpha-200);
+    border-radius: 0.5rem;
+    width: 200px;
+    height: 5rem;
+    box-sizing: border-box;
+    position: relative;
+}
+
+.tripInfoBox {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    height: 100%;
+    font-size: 0.9rem;
+    width: 100%;
+}
+
+.timeUntilDeparture {
+    color: var(--foreground);
+    opacity: 0.8;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    text-align: center;
 }
 
 .expandIcon {
-    font-size: 0.875rem;
-    transition: transform 0.3s ease;
+    color: var(--foreground);
+    opacity: 0.6;
+    cursor: pointer;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.3s ease-in-out;
+    box-sizing: border-box;
+    position: absolute;
+    right: -2rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1.5rem;
+    height: 1.5rem;
 }
 
-.tripOption .tripDetails {
-    max-height: 0;
+.tripDetails {
     overflow: hidden;
     opacity: 0;
-    transition: all 0.3s ease-in-out;
+    max-height: 0;
+    transition: max-height 0.5s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.3s ease-in-out,
+                padding 0.3s ease-in-out,
+                margin 0.3s ease-in-out;
+    padding: 0 1.25rem;
     margin-top: 0;
+    border-top: 1px solid var(--gray-alpha-200);
+    background-color: var(--gray-alpha-100);
+}
+
+.tripDetails.visible {
+    opacity: 1;
+    max-height: 2000px;
+    padding: 1.25rem;
+    margin-top: 1rem;
 }
 
 .tripOption.expanded .tripDetails {
-    max-height: 1000px; /* Adjust based on your content */
+    max-height: 1000px;
     opacity: 1;
     margin-top: 1rem;
 }
@@ -293,68 +362,14 @@
     outline-offset: 2px;
 }
 
-.tripMainInfo {
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-    gap: 1rem;
-}
-
-.stationContainer {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.stationContainer.right {
-    text-align: right;
-}
-
-.stationName {
-    font-size: 1rem;
-    font-weight: 500;
-}
-
-.stationTime {
-    font-size: 0.9rem;
-    color: var(--foreground);
-    opacity: 0.8;
-}
-
-.tripTimes {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 1.25rem;
-    font-weight: 500;
-}
-
-.timeArrow {
-    color: var(--foreground);
-    opacity: 0.5;
-}
-
-.stationNames {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--foreground);
-    opacity: 0.8;
-    font-size: 0.9rem;
-}
-
-.stationArrow {
-    opacity: 0.5;
-}
-
 .tripExtendedInfo {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    margin-bottom: 1rem;
     padding: 1rem;
     background-color: var(--gray-alpha-100);
     border-radius: 0.5rem;
+    box-sizing: border-box;
 }
 
 .transportLines {
@@ -362,6 +377,7 @@
     flex-direction: row;
     gap: 1rem;
     flex-wrap: wrap;
+    box-sizing: border-box;
 }
 
 .transportLine {
@@ -373,6 +389,7 @@
     font-size: 0.95rem;
     background-color: var(--gray-alpha-200);
     white-space: nowrap;
+    box-sizing: border-box;
 }
 
 .trainLineIndicator {
@@ -380,12 +397,14 @@
     height: 1rem;
     border-radius: 50%;
     flex-shrink: 0;
+    box-sizing: border-box;
 }
 
 .trainLine {
     margin-top: 4px;
     color: #b3b3b3;
     font-size: 0.9em;
+    box-sizing: border-box;
 }
 
 .totalTripDuration {
@@ -395,9 +414,39 @@
     font-weight: 500;
     padding-top: 0.5rem;
     border-top: 1px solid var(--gray-alpha-200);
+    box-sizing: border-box;
+}
+
+@media (prefers-color-scheme: dark) {
+    .page {
+        --gray-rgb: 255, 255, 255;
+        --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
+        --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
+
+        --button-primary-hover: #ccc;
+        --button-secondary-hover: #1a1a1a;
+    }
 }
 
 @media (max-width: 37.5rem) {
+    .page {
+        padding: 0 0 1rem 0;
+    }
+
+    .main {
+        align-items: center;
+        padding: 0 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .tripContent {
+        margin-bottom: 1rem;
+    }
+
+    .backButton {
+        margin: 0.75rem 0 0 1rem;
+    }
+
     .tripTimes {
         font-size: 1rem;
     }

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -1,22 +1,7 @@
-.pageTitle,
-.tripOption h2,
-.tripList li,
-.timeInfo,
-.transportInfo,
-.durationInfo,
-.legsInfo {
-    font-family: inherit;
-}
-
 .page {
     --gray-rgb: 0, 0, 0;
     --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
     --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-    --header-offset: 170px;
-
-    --button-primary-hover: #383838;
-    --button-secondary-hover: #f2f2f2;
-
     display: grid;
     grid-template-rows: auto 1fr auto;
     align-items: start;
@@ -25,7 +10,6 @@
     padding: 0 0 2rem 0;
     gap: 1rem;
     font-family: var(--font-geist-sans);
-    box-sizing: border-box;
 }
 
 .main {
@@ -34,14 +18,12 @@
     width: 100%;
     max-width: 75rem;
     padding: 1rem 2rem 0 2rem;
-    box-sizing: border-box;
 }
 
 .tripContent {
     width: 100%;
     padding: 0 1.25rem;
     margin-bottom: 2rem;
-    box-sizing: border-box;
 }
 
 .container {
@@ -49,9 +31,7 @@
     padding: 1.25rem;
     max-width: 75rem;
     margin: 0 auto;
-    font-family: inherit;
     padding-top: 2rem;
-    box-sizing: border-box;
 }
 
 .backButton {
@@ -62,7 +42,6 @@
     color: var(--foreground);
     cursor: pointer;
     transition: all 0.3s ease;
-    box-sizing: border-box;
 }
 
 .backButton:hover {
@@ -70,12 +49,10 @@
 }
 
 .pageTitle {
-    margin: 0rem 0 1.25rem 0;
     font-size: 1.5rem;
     font-weight: 500;
     text-align: center;
     padding-bottom: 1rem;
-    box-sizing: border-box;
 }
 
 .tripOption {
@@ -86,7 +63,6 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     box-shadow: 0 2px 12px rgba(var(--gray-rgb), 0.1);
     cursor: pointer;
-    box-sizing: border-box;
 }
 
 .tripOption:hover {
@@ -99,20 +75,17 @@
     margin-bottom: 0.9375rem;
     font-size: 1.2rem;
     font-weight: 500;
-    box-sizing: border-box;
 }
 
 .tripList {
     list-style: none;
     padding: 1rem;
     margin: 0;
-    box-sizing: border-box;
 }
 
 .legGroup {
     position: relative;
     margin-bottom: 16px;
-    box-sizing: border-box;
 }
 
 .legGroup:last-child {
@@ -122,7 +95,6 @@
 .legContent {
     position: relative;
     padding-left: 20px;
-    box-sizing: border-box;
 }
 
 .legContent::before {
@@ -138,7 +110,6 @@
 
 .tripItem {
     margin-bottom: 8px;
-    box-sizing: border-box;
 }
 
 .tripItem:last-child {
@@ -149,14 +120,12 @@
     margin-top: 4px;
     color: #b3b3b3;
     font-size: 0.9em;
-    box-sizing: border-box;
 }
 
 .legDivider {
     margin: 16px 0;
     border: none;
     border-top: 1px solid #e0e0e0;
-    box-sizing: border-box;
 }
 
 .timeInfo {
@@ -164,94 +133,94 @@
     opacity: 0.8;
     font-size: 0.95rem;
     padding-top: 0.5rem;
-    box-sizing: border-box;
 }
 
 .transportInfo {
     margin-top: 0.625rem;
     font-weight: 500;
-    box-sizing: border-box;
 }
 
 .durationInfo {
     color: var(--foreground);
     opacity: 0.8;
     font-size: 0.9rem;
-    box-sizing: border-box;
+}
+
+.stationContainer {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-height: 64px;
+    padding: 0.5rem;
+    justify-content: center;
+}
+
+.stationContainer.right {
+    align-items: flex-end;
+    text-align: right;
+}
+
+.stationName {
+    font-weight: 500;
+    font-size: 1rem;
+}
+
+.stationTime {
+    font-size: 0.9rem;
+    opacity: 0.8;
 }
 
 .legsInfo {
-    margin: 0;
+    position: absolute;
+    bottom: -30px;
+    left: 0;
+    margin-top: 3rem;
     padding: 0.375rem 0.75rem;
     background-color: rgba(255, 152, 0, 0.1);
     border: 1px solid rgba(255, 152, 0, 0.2);
     border-radius: 0.25rem;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: var(--foreground);
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
     white-space: nowrap;
-    box-sizing: border-box;
-    width: fit-content;
 }
 
 .legsInfo::before {
     content: "⚠️";
 }
 
-.stationContainer {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    width: 200px;
-    height: 64px;
-    padding: 0.5rem;
-    box-sizing: border-box;
-    position: relative;
-    justify-content: center;
-}
-
-.stationContainer.right {
-    text-align: right;
-    padding-right: 1rem;
-}
-
-.stationContainer .legsInfo {
+.arrivalDifference {
     position: absolute;
-    top: 100%;
-    left: 0.5rem;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.8rem;
-    z-index: 1;
-}
-
-.stationName {
-    font-size: 1rem;
-    font-weight: 500;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.stationTime {
-    font-size: 0.9rem;
+    bottom: -30px;
+    right: 0;
+    margin-top: 3rem;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.85rem;
     color: var(--foreground);
     opacity: 0.8;
+    font-style: italic;
     white-space: nowrap;
 }
 
 .tripStatusSection {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    margin-top: 0.5rem;
     background-color: var(--gray-alpha-100);
     border: 1px solid var(--gray-alpha-200);
-    border-radius: 0.5rem;
     width: 200px;
-    box-sizing: border-box;
     position: relative;
+}
+
+.tripStatusDeparted {
+    background-color: rgba(255, 0, 0, 0.1);
+}
+
+.tripStatusUpcoming {
+    background-color: rgba(0, 255, 0, 0.1);
 }
 
 .tripInfoBox {
@@ -281,7 +250,6 @@
     align-items: center;
     justify-content: center;
     transition: transform 0.3s ease-in-out;
-    box-sizing: border-box;
     position: absolute;
     right: -2rem;
     top: 50%;
@@ -323,7 +291,6 @@
     padding: 1rem;
     background-color: var(--gray-alpha-100);
     border-radius: 0.5rem;
-    box-sizing: border-box;
 }
 
 .transportLines {
@@ -331,7 +298,6 @@
     flex-direction: row;
     gap: 1rem;
     flex-wrap: wrap;
-    box-sizing: border-box;
 }
 
 .transportLine {
@@ -343,7 +309,6 @@
     font-size: 0.95rem;
     background-color: var(--gray-alpha-200);
     white-space: nowrap;
-    box-sizing: border-box;
 }
 
 .trainLineIndicator {
@@ -351,14 +316,12 @@
     height: 1rem;
     border-radius: 50%;
     flex-shrink: 0;
-    box-sizing: border-box;
 }
 
 .trainLine {
     margin-top: 4px;
     color: #b3b3b3;
     font-size: 0.9em;
-    box-sizing: border-box;
 }
 
 .totalTripDuration {
@@ -368,7 +331,6 @@
     font-weight: 500;
     padding-top: 0.5rem;
     border-top: 1px solid var(--gray-alpha-200);
-    box-sizing: border-box;
 }
 
 .tripSummary {
@@ -378,7 +340,6 @@
     width: 100%;
     padding: 2rem 3rem 2rem 2rem;
     height: 10rem;
-    box-sizing: border-box;
 }
 
 .tripMainInfo {
@@ -393,6 +354,21 @@
     align-items: center;
     gap: 2rem;
     margin-left: auto;
+}
+
+.tripHeading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    padding: 0 1rem;
+}
+
+.timePreferenceText {
+    color: var(--gray-500);
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding-bottom: 0.5rem;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -25,9 +25,7 @@
 .tripContent {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
     width: 100%;
-    padding: 0;
     margin-bottom: 2rem;
     flex: 1;
 }
@@ -35,17 +33,22 @@
 .stationContainer {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    padding: 0.5rem 0;
+    position: relative;
 }
 
 .stationName {
     font-size: 1rem;
     font-weight: 500;
+    margin-bottom: 0.25rem;
+    padding-top: 0.25rem;
 }
 
 .stationTime {
     font-size: 0.9rem;
     color: var(--gray-alpha-900);
+    padding-bottom: 0.25rem;
+    opacity: 0.8;
 }
 
 .tripMainInfo {
@@ -64,6 +67,24 @@
 .tripDetails {
     font-size: 0.9rem;
     margin-bottom: 1rem;
+    overflow: hidden;
+    opacity: 0;
+    max-height: 0;
+    visibility: visible;
+    transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    padding: 0 1.25rem;
+    margin-top: 0;
+    border-top: 1px solid var(--gray-alpha-200);
+    background-color: var(--gray-alpha-100);
+    transform: translateY(-10px);
+}
+
+.tripDetails.visible {
+    opacity: 1;
+    max-height: 2000px;
+    padding: 1.25rem;
+    margin-top: 1rem;
+    transform: translateY(0);
 }
 
 .timeDifference {
@@ -71,121 +92,278 @@
     color: var(--gray-alpha-700);
 }
 
-/* Mobile Styles */
-@media (max-width: 768px) {
-    .main {
-        padding: 1rem;
-    }
-
-    .tripMainInfo {
-        gap: 1rem;
-    }
-
-    .stationTime {
-        font-size: 0.85rem;
-    }
+.tripSummary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 1rem 3rem 1rem 2rem;
+    height: 9rem;
 }
 
-@media (max-width: 480px) {
-    .page {
-        padding-top: 7rem;
-    }
-
-    .main {
-        padding: 0.75rem;
-    }
-
-    .tripOption {
-        padding: 1rem;
-    }
-
-    .tripMainInfo {
-        flex-direction: column;
-        gap: 0.75rem;
-    }
-
-    .stationContainer {
-        width: 100%;
-    }
-
-    .stationContainer.right {
-        border-top: 1px solid var(--gray-alpha-200);
-        padding-top: 0.75rem;
-    }
-
-    .stationName {
-        font-size: 0.95rem;
-    }
-
-    .stationTime {
-        font-size: 0.85rem;
-    }
-
-    .timeDifference {
-        font-size: 0.75rem;
-    }
-
-    .tripDetails {
-        font-size: 0.85rem;
-    }
+.rightSection {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    margin-left: auto;
+    position: relative;
+    margin-right: 1.5rem;
 }
 
-@media (max-width: 360px) {
-    .main {
-        padding: 0.5rem;
-    }
-
-    .tripOption {
-        padding: 0.875rem;
-    }
-
-    .stationName {
-        font-size: 0.9rem;
-    }
-
-    .stationTime {
-        font-size: 0.8rem;
-    }
+.legsInfo {
+    padding: 0.25rem 0.75rem;
+    background-color: rgba(255, 152, 0, 0.1);
+    border: 1px solid rgba(255, 152, 0, 0.2);
+    border-radius: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--foreground);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    white-space: nowrap;
+    position: absolute;
+    top: -1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    min-width: 6.875rem;
+    z-index: 1;
 }
 
-@media (display-mode: standalone) {
-    .page {
-        padding-top: 11rem;
-    }
+.legsInfo::before {
+    content: "⚠️";
 }
 
-.horizontalDiv {
+.tripStatusSection {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    margin-top: 0.5rem;
+    padding-right: 1rem;
+    background-color: var(--gray-alpha-100);
+    border: 1px solid var(--gray-alpha-200);
+    width: auto;
+    min-width: 6.875rem;
+    position: relative;
+}
+
+.arrivalDifference {
+    position: absolute;
+    bottom: -30px;
+    right: 0;
+    margin-top: 3rem;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.85rem;
+    color: var(--foreground);
+    opacity: 0.8;
+    font-style: italic;
+    white-space: nowrap;
+}
+
+.tripStatusDeparted {
+    background-color: rgba(255, 0, 0, 0.1);
+}
+
+.tripStatusUpcoming {
+    background-color: rgba(0, 255, 0, 0.1);
+}
+
+.tripInfoBox {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    font-size: 0.9rem;
+    width: 100%;
+}
+
+.timeUntilDeparture {
+    color: var(--foreground);
+    opacity: 0.8;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    text-align: center;
+}
+
+.expandIcon {
+    color: var(--foreground);
+    opacity: 0.6;
+    cursor: pointer;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.3s ease-in-out;
+    position: absolute;
+    right: -2rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1.5rem;
+    height: 1.5rem;
+    transform-origin: center center;
+}
+
+.tripOption.expanded .expandIcon {
+    transform: translateY(-50%) rotate(180deg);
+}
+
+.tripExtendedInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+    background-color: var(--gray-alpha-100);
+    border-radius: 0.5rem;
+}
+
+.transportLines {
     display: flex;
     flex-direction: row;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
-.container {
-    width: 100%;
-    padding: 1.25rem;
-    max-width: 75rem;
-    margin: 0 auto;
-    padding-top: 2rem;
+.transportLine {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.95rem;
+    background-color: var(--gray-alpha-200);
+    white-space: nowrap;
 }
 
-.backButton {
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--border-color, #ddd);
-    border-radius: 0.3125rem;
-    background-color: transparent;
-    color: var(--foreground);
-    cursor: pointer;
-    transition: all 0.3s ease;
+.trainLineIndicator {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    flex-shrink: 0;
 }
 
-.backButton:hover {
-    background-color: rgba(45, 45, 45, 0.25);
+.trainLine {
+    margin-top: 4px;
+    color: #666;
+    font-size: 0.9em;
 }
 
-.pageTitle {
-    font-size: 1.5rem;
+.totalTripDuration {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     font-weight: 500;
-    text-align: center;
-    padding-bottom: 1rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--gray-alpha-200);
+}
+
+.tripSummary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 1.5rem 3rem 0rem 2rem;
+    height: 7rem;
+}
+
+.tripMainInfo {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    scroll-margin-top: var(--header-offset);
+    flex: 1;
+    margin-right: 2rem;
+}
+
+.tripHeading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    padding: 0 1rem;
+}
+
+.timePreferenceText {
+    color: var(--gray-500);
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding-bottom: 0.5rem;
+}
+
+.tripLegs {
+    padding: 1rem 0rem;
+}
+
+.tripLegSeparator {
+    margin: 1rem 0;
+    text-align: left;
+    padding-left: 1rem;
+}
+
+.tripLegDivider {
+    height: 0;  
+    margin: 0.5rem 0;
+    width: calc(100% - 20px);
+    border-top: 1px solid #e0e0e0;  
+}
+
+.waitTimeIndicator {
+    color: #666;
+    font-size: 0.95em;
+    padding: 0.5rem 0.75rem;
+    margin: 0.5rem 0;
+    background-color: var(--gray-alpha-100);
+    border-radius: 0.25rem;
+    display: inline-block;
+}
+
+.tripLeg {
+    position: relative;
+    padding-left: 1rem;
+    border-left: 0.2rem solid var(--line-color, #e0e0e0);
+}
+
+.sectionTitle {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 1.5rem 0 1rem;
+    color: #333;
+}
+
+.pastJourney {
+    border-left: 4px solid #666;
+    opacity: 0.85;
+}
+
+.tripStatusDeparted {
+    background-color: #666;
+    color: #fff;
+}
+
+.nextTrip {
+    border-left: 5px solid #2196f3 !important;
+    box-shadow: 0 -3px 8px rgba(33, 150, 243, 0.2), 
+                0 3px 8px rgba(33, 150, 243, 0.2), 
+                2px 0 8px rgba(33, 150, 243, 0.1) !important;
+    position: relative;
+    background-color: rgba(33, 150, 243, 0.03) !important;
+}
+
+.nextTrip::before {
+    content: 'Closest Trip';
+    position: absolute;
+    top: -10px;
+    left: 16px;
+    background: #2196f3;
+    color: white;
+    padding: 3px 10px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    z-index: 1;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .tripOption {
@@ -281,327 +459,224 @@
     font-size: 0.9rem;
 }
 
-.stationContainer {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    min-height: 64px;
-    padding: 0.5rem;
-    justify-content: center;
-}
-
-.stationContainer.right {
-    align-items: flex-end;
-    text-align: right;
-    margin-left: auto;
-    margin-right: 1rem;
-}
-
-.stationName {
-    font-weight: 500;
-    font-size: 1rem;
-}
-
-.stationTime {
-    font-size: 0.9rem;
-    opacity: 0.8;
-}
-
-.rightSection {
-    display: flex;
-    align-items: center;
-    gap: 2rem;
-    margin-left: auto;
-    position: relative;
-}
-
-.legsInfo {
-    padding: 0.375rem 0.75rem;
-    background-color: rgba(255, 152, 0, 0.1);
-    border: 1px solid rgba(255, 152, 0, 0.2);
-    border-radius: 0.25rem;
-    font-size: 0.85rem;
-    color: var(--foreground);
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    position: absolute;
-    top: -35px;
-    left: 50%;
-    transform: translateX(-50%);
-    white-space: nowrap;
-}
-
-.legsInfo::before {
-    content: "⚠️";
-}
-
-.tripStatusSection {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem;
-    border-radius: 0.5rem;
-    margin-top: 0.5rem;
-}
-
-.arrivalDifference {
-    position: absolute;
-    bottom: -30px;
-    right: 0;
-    margin-top: 3rem;
-    padding: 0.375rem 0.75rem;
-    font-size: 0.85rem;
-    color: var(--foreground);
-    opacity: 0.8;
-    font-style: italic;
-    white-space: nowrap;
-}
-
-.tripStatusSection {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem;
-    border-radius: 0.5rem;
-    margin-top: 0.5rem;
-    background-color: var(--gray-alpha-100);
-    border: 1px solid var(--gray-alpha-200);
-    width: 6.875rem;
-    position: relative;
-}
-
-.tripStatusDeparted {
-    background-color: rgba(255, 0, 0, 0.1);
-}
-
-.tripStatusUpcoming {
-    background-color: rgba(0, 255, 0, 0.1);
-}
-
-.tripInfoBox {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    font-size: 0.9rem;
+.container {
     width: 100%;
-}
-
-.timeUntilDeparture {
-    color: var(--foreground);
-    opacity: 0.8;
-    font-size: 0.9rem;
-    white-space: nowrap;
-    text-align: center;
-}
-
-.expandIcon {
-    color: var(--foreground);
-    opacity: 0.6;
-    cursor: pointer;
-    font-size: 0.8rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: transform 0.3s ease-in-out;
-    position: absolute;
-    right: -2rem;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 1.5rem;
-    height: 1.5rem;
-    transform-origin: center center;
-}
-
-.tripOption.expanded .expandIcon {
-    transform: translateY(-50%) rotate(180deg);
-}
-
-.tripDetails {
-    overflow: hidden;
-    opacity: 0;
-    max-height: 0;
-    visibility: visible;
-    transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-    padding: 0 1.25rem;
-    margin-top: 0;
-    border-top: 1px solid var(--gray-alpha-200);
-    background-color: var(--gray-alpha-100);
-    transform: translateY(-10px);
-}
-
-.tripDetails.visible {
-    opacity: 1;
-    max-height: 2000px;
     padding: 1.25rem;
-    margin-top: 1rem;
-    transform: translateY(0);
+    max-width: 75rem;
+    margin: 0 auto;
+    padding-top: 2rem;
 }
 
-.tripExtendedInfo {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding: 1rem;
-    background-color: var(--gray-alpha-100);
-    border-radius: 0.5rem;
+.backButton {
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border-color, #ddd);
+    border-radius: 0.3125rem;
+    background-color: transparent;
+    color: var(--foreground);
+    cursor: pointer;
+    transition: all 0.3s ease;
 }
 
-.transportLines {
+.backButton:hover {
+    background-color: rgba(45, 45, 45, 0.25);
+}
+
+.horizontalDiv {
     display: flex;
     flex-direction: row;
-    gap: 1rem;
-    flex-wrap: wrap;
 }
 
-.transportLine {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.25rem;
-    font-size: 0.95rem;
-    background-color: var(--gray-alpha-200);
+.rightSection .tripStatusSection,
+.rightSection .legsInfo {
+    padding-right: 1.25rem;
+    width: auto;
+    max-width: 100%;
+    text-overflow: ellipsis;
     white-space: nowrap;
+    overflow: hidden;
 }
 
-.trainLineIndicator {
-    width: 1rem;
-    height: 1rem;
-    border-radius: 50%;
-    flex-shrink: 0;
+@media (max-width: 768px) {
+    .main {
+        padding: 1rem;
+    }
+
+    .tripMainInfo {
+        gap: 1rem;
+    }
+
+    .stationTime {
+        font-size: 0.85rem;
+    }
+    
+    .tripContent {
+        margin-bottom: 1rem;
+    }
+    
+    .backButton {
+        margin: 0.75rem 0 0 1rem;
+    }
+    
+    .tripTimes {
+        font-size: 1rem;
+    }
+    
+    .stationNames {
+        font-size: 0.8rem;
+    }
+    
+    .tripExtendedInfo {
+        flex-direction: column;
+        gap: 1rem;
+    }
 }
 
-.trainLine {
-    margin-top: 4px;
-    color: #666;
-    font-size: 0.9em;
+@media (max-width: 480px) {
+    .rightSection {
+        margin-right: 2.5rem;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .tripMainInfo {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .tripOption {
+        padding: 1.25rem 1rem;
+    }
+    
+    .main {
+        padding: 0.75rem;
+        align-items: center;
+        margin-bottom: 1rem;
+    }
+    
+    .page {
+        padding-top: 7rem;
+        --header-offset: 120px;
+    }
+    
+    .stationName {
+        font-size: 0.95rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .stationTime {
+        font-size: 0.85rem;
+    }
+
+    .timeDifference {
+        font-size: 0.75rem;
+    }
+
+    .tripDetails {
+        font-size: 0.85rem;
+    }
+
+    .expandIcon {
+        display: none !important;
+    }
+
+    .legsInfo {
+        top: -2rem;
+        left: 40%;
+        transform: translateX(-50%);
+        min-width: unset;
+        max-width: 90%;
+        font-size: 0.75rem;
+    }
+
+    .tripStatusSection {
+        position: relative;
+        padding-right: 1.5rem;
+        margin-right: 1.5rem;
+    }
+    
+    .tripSummary {
+        padding: 1rem 1.5rem 1rem 1rem;
+    }
+    
+    .nextTrip {
+        position: relative;
+    }
+    
+    .nextTrip::before {
+        content: 'Closest Trip';
+        position: absolute;
+        top: -10px;
+        left: 16px;
+        background: #2196f3;
+        color: white;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 0.7rem;
+        font-weight: 500;
+        z-index: 1;
+    }
 }
 
-.totalTripDuration {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-weight: 500;
-    padding-top: 0.5rem;
-    border-top: 1px solid var(--gray-alpha-200);
+@media (max-width: 360px) {
+    .main {
+        padding: 0.5rem;
+    }
+
+    .tripOption {
+        padding: 1.5rem 0.875rem 1.25rem;
+    }
+
+    .stationContainer {
+        padding: 0.25rem 0;
+    }
+
+    .stationName {
+        font-size: 0.9rem;
+        margin-bottom: 0.15rem;
+        padding-top: 0.15rem;
+    }
+
+    .stationTime {
+        font-size: 0.8rem;
+        padding-bottom: 0.15rem;
+    }
+    
+    .rightSection {
+        margin-left: 0.25rem;
+        gap: 0.5rem;
+        padding-right: 1rem;
+    }
+    
+    .legsInfo {
+        top: -1.75rem;
+        left: 45%;
+        max-width: 85%;
+        font-size: 0.7rem;
+        padding: 0.25rem 0.5rem;
+    }
+    
+    .tripStatusSection {
+        padding-right: 1rem;
+        margin-right: 1rem;
+    }
+    
+    .tripSummary {
+        padding: 0.75rem 1rem 0.75rem 0.75rem;
+    }
+    
+    .nextTrip::before {
+        font-size: 0.65rem;
+        padding: 1px 6px;
+        left: 12px;
+    }
 }
 
-.tripSummary {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    padding: 1rem 3rem 1rem 2rem;
-    height: 9rem;
-}
-
-.tripMainInfo {
-    display: flex;
-    align-items: center;
-    gap: 2rem;
-    scroll-margin-top: var(--header-offset);
-    flex: 1;
-    margin-right: 1rem;
-}
-
-.rightSection {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.5rem;
-    margin-left: auto;
-}
-
-.tripHeading {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-    padding: 0 1rem;
-}
-
-.timePreferenceText {
-    color: var(--gray-500);
-    font-size: 0.875rem;
-    font-weight: 500;
-    padding-bottom: 0.5rem;
-}
-
-/*  */
-.tripLegs {
-    padding: 1rem 0rem;
-
-}
-
-/* The space between the top leg and the wait time indicator */
-.tripLegSeparator {
-    margin: 1rem 0;
-    text-align: left;
-    padding-left: 1rem;
-}
-
-.tripLegDivider {
-    height: 0;  
-    margin: 0.5rem 0;
-    width: calc(100% - 20px);
-    border-top: 1px solid #e0e0e0;  
-}
-
-.waitTimeIndicator {
-    color: #666;
-    font-size: 0.95em;
-    padding: 0.5rem 0.75rem;
-    margin: 0.5rem 0;
-    background-color: var(--gray-alpha-100);
-    border-radius: 0.25rem;
-    display: inline-block;
-}
-
-.tripLeg {
-    position: relative;
-    padding-left: 1rem;
-    border-left: 0.2rem solid var(--line-color, #e0e0e0);
-}
-
-.sectionTitle {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin: 1.5rem 0 1rem;
-    color: #333;
-}
-
-.pastJourney {
-    border-left: 4px solid #666;
-    opacity: 0.85;
-}
-
-.tripStatusDeparted {
-    background-color: #666;
-    color: #fff;
-}
-
-.nextTrip {
-    border-left: 4px solid #2196f3;
-    box-shadow: 0 2px 8px rgba(33, 150, 243, 0.1);
-    position: relative;
-}
-
-.nextTrip::before {
-    content: 'Closest Trip';
-    position: absolute;
-    top: -10px;
-    left: 16px;
-    background: #2196f3;
-    color: white;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 0.8rem;
-    font-weight: 500;
-    z-index: 1;
+@media (display-mode: standalone) {
+    .page {
+        padding-top: 11rem;
+    }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -624,43 +699,9 @@
     }
 }
 
-@media (max-width: 37.5rem) {
-    .page {
-        --header-offset: 120px;
-        padding: 0 0 1rem 0;
-    }
-
-    .main {
-        align-items: center;
-        padding: 0 1rem;
-        margin-bottom: 1rem;
-    }
-
-    .tripContent {
-        margin-bottom: 1rem;
-    }
-
-    .backButton {
-        margin: 0.75rem 0 0 1rem;
-    }
-
-    .tripTimes {
-        font-size: 1rem;
-    }
-
-    .stationNames {
-        font-size: 0.8rem;
-    }
-
-    .tripExtendedInfo {
-        flex-direction: column;
-        gap: 1rem;
-    }
-}
-
 @media (display-mode: standalone) {
     .page {
-        padding-top: 11rem; /* Adjusted for standalone mode */
+        padding-top: 11rem;
     }
 }
 

--- a/ripview/src/app/tripPlanning/tripPlanning.module.css
+++ b/ripview/src/app/tripPlanning/tripPlanning.module.css
@@ -2,12 +2,14 @@
     --gray-rgb: 0, 0, 0;
     --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
     --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
+    --button-primary-hover: #383838;
+    --button-secondary-hover: #f2f2f2;
     display: flex;
     flex-direction: column;
     min-height: 100vh;
     width: 100%;
     font-family: var(--font-geist-sans);
-    padding-top: calc(4rem + 3rem); /* Header + SubHeader height */
+    padding-top: 8rem;
 }
 
 .main {
@@ -15,17 +17,146 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    max-width: 75rem;
-    padding: 1rem 2rem 0 2rem;
+    max-width: 1200px;
     margin: 0 auto;
-    font-family: var(--font-geist-sans);
+    padding: 1rem 2rem;
 }
 
 .tripContent {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
     width: 100%;
-    padding: 0 1.25rem;
+    padding: 0;
     margin-bottom: 2rem;
     flex: 1;
+}
+
+.stationContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.stationName {
+    font-size: 1rem;
+    font-weight: 500;
+}
+
+.stationTime {
+    font-size: 0.9rem;
+    color: var(--gray-alpha-900);
+}
+
+.tripMainInfo {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+}
+
+.tripOption {
+    border: 1px solid var(--gray-alpha-200);
+    border-radius: 0.75rem;
+    transition: background-color 0.2s ease;
+}
+
+.tripDetails {
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+}
+
+.timeDifference {
+    font-size: 0.8rem;
+    color: var(--gray-alpha-700);
+}
+
+/* Mobile Styles */
+@media (max-width: 768px) {
+    .main {
+        padding: 1rem;
+    }
+
+    .tripMainInfo {
+        gap: 1rem;
+    }
+
+    .stationTime {
+        font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .page {
+        padding-top: 7rem;
+    }
+
+    .main {
+        padding: 0.75rem;
+    }
+
+    .tripOption {
+        padding: 1rem;
+    }
+
+    .tripMainInfo {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .stationContainer {
+        width: 100%;
+    }
+
+    .stationContainer.right {
+        border-top: 1px solid var(--gray-alpha-200);
+        padding-top: 0.75rem;
+    }
+
+    .stationName {
+        font-size: 0.95rem;
+    }
+
+    .stationTime {
+        font-size: 0.85rem;
+    }
+
+    .timeDifference {
+        font-size: 0.75rem;
+    }
+
+    .tripDetails {
+        font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 360px) {
+    .main {
+        padding: 0.5rem;
+    }
+
+    .tripOption {
+        padding: 0.875rem;
+    }
+
+    .stationName {
+        font-size: 0.9rem;
+    }
+
+    .stationTime {
+        font-size: 0.8rem;
+    }
+}
+
+@media (display-mode: standalone) {
+    .page {
+        padding-top: 11rem;
+    }
+}
+
+.horizontalDiv {
+    display: flex;
+    flex-direction: row;
 }
 
 .container {
@@ -524,6 +655,12 @@
     .tripExtendedInfo {
         flex-direction: column;
         gap: 1rem;
+    }
+}
+
+@media (display-mode: standalone) {
+    .page {
+        padding-top: 11rem; /* Adjusted for standalone mode */
     }
 }
 

--- a/ripview/src/components/BackButton.module.css
+++ b/ripview/src/components/BackButton.module.css
@@ -7,11 +7,12 @@
     color: var(--foreground);
     cursor: pointer;
     transition: all 0.2s ease;
-    margin: 0rem 1rem 1rem 2rem;
+    margin: 0;
     display: flex;
     align-items: center;
     gap: 0.5rem;
     font-size: 0.875rem;
+    height: 2rem;
 }
 
 .backButton:hover {
@@ -26,7 +27,6 @@
 @media (max-width: 37.5rem) {
     .backButton {
         padding: 0.375rem;
-        height: 1.75rem;
         min-width: 1.75rem;
     }
 }

--- a/ripview/src/components/Header.module.css
+++ b/ripview/src/components/Header.module.css
@@ -1,28 +1,29 @@
 .navBar {
-    position: sticky;
+    position: fixed;
     top: 0;
-    display: flex;
+    left: 0;
+    display: grid;
+    grid-template-columns: 180px 1fr 180px;
     align-items: center;
-    padding: 1.5rem;
+    padding: 0 1.5rem;
     background-color: var(--background);
     border-bottom: 0.0625rem solid var(--gray-alpha-200);
     z-index: 10;
     width: 100%;
-    justify-content: center;
+    height: 4rem;
 }
 
 .navBar h1 {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    text-align: center;
-    font-size: 1.5rem;
     margin: 0;
+    font-size: 1.5rem;
+    text-align: center;
+    grid-column: 2;
 }
 
 .lightLogo {
-    position: absolute;
-    left: 1.5rem;
+    height: 2rem;
+    width: auto;
+    grid-column: 1;
 }
 
 .mapButton {
@@ -34,8 +35,8 @@
     font-size: 0.9rem;
     cursor: pointer;
     transition: background-color 0.3s ease;
-    margin-left: auto;
-    margin-right: 2.5rem;
+    grid-column: 3;
+    justify-self: end;
 }
 
 .mapButton:hover {

--- a/ripview/src/components/Header.module.css
+++ b/ripview/src/components/Header.module.css
@@ -30,9 +30,59 @@
     left: 50%;
     transform: translateX(-50%);
     text-align: center;
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     margin: 0;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 70%;
+    padding: 0 0.5rem;
+}
+
+.verticalTitle {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    line-height: 1.1;
+    width: 100%;
+}
+
+.verticalTitle .stationName {
+    font-weight: 500;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: center;
+    font-size: 1.1em;
+}
+
+.verticalTitle .arrow {
+    font-size: 1em;
+    margin: 0.1em 0;
+    line-height: 0.7;
+}
+
+/* Responsive styles for vertical title */
+@media (max-width: 480px) {
+    .verticalTitle .stationName {
+        font-size: 0.9em;
+    }
+    
+    .verticalTitle .arrow {
+        font-size: 1em;
+        margin: 0.1em 0;
+    }
+}
+
+@media (max-width: 360px) {
+    .verticalTitle .stationName {
+        font-size: 0.8em;
+    }
+    
+    .verticalTitle .arrow {
+        font-size: 0.9em;
+    }
 }
 
 .lightLogo {
@@ -68,5 +118,47 @@
 @media (prefers-color-scheme: light) {
     .lightLogo {
         position: inherit;
+    }
+}
+
+/* Adjust responsive sizes now that we have shorter station names */
+@media (max-width: 768px) {
+    .navBar h1 {
+        font-size: 1.2rem;
+        max-width: 75%;
+    }
+}
+
+@media (max-width: 480px) {
+    .navBar h1 {
+        font-size: 0.95rem;
+        max-width: 80%;
+        letter-spacing: -0.01em;
+    }
+}
+
+@media (max-width: 360px) {
+    .navBar h1 {
+        font-size: 0.85rem;
+        max-width: 85%;
+        letter-spacing: -0.02em;
+    }
+}
+
+/* Add extra small screen breakpoint */
+@media (max-width: 320px) {
+    .navBar h1 {
+        font-size: 0.75rem;
+        max-width: 90%;
+        letter-spacing: -0.03em;
+    }
+}
+
+/* For extremely small screens or extremely long station names */
+@media (max-width: 280px) {
+    .navBar h1 {
+        font-size: 0.7rem;
+        max-width: 90%;
+        letter-spacing: -0.03em;
     }
 }

--- a/ripview/src/components/Header.module.css
+++ b/ripview/src/components/Header.module.css
@@ -1,29 +1,45 @@
+@media (display-mode: standalone) {
+    .navBar {
+        padding-top: 4rem !important;
+        height: 7rem !important;
+    }
+}
+
+@media (display-mode: browser) {
+    .navBar {
+        height: 5rem !important;
+    }
+}
+
 .navBar {
     position: fixed;
     top: 0;
     left: 0;
-    display: grid;
-    grid-template-columns: 180px 1fr 180px;
+    right: 0;
+    display: flex;
     align-items: center;
-    padding: 0 1.5rem;
     background-color: var(--background);
     border-bottom: 0.0625rem solid var(--gray-alpha-200);
     z-index: 10;
     width: 100%;
-    height: 4rem;
+    justify-content: space-between;
 }
 
 .navBar h1 {
-    margin: 0;
-    font-size: 1.5rem;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
     text-align: center;
-    grid-column: 2;
+    font-size: 1.5rem;
+    margin: 0;
+    white-space: nowrap;
 }
 
 .lightLogo {
-    height: 2rem;
-    width: auto;
-    grid-column: 1;
+    margin-right: auto;
+    margin-left: 2rem;
+    border: none;
+    /* justify-content: flex-start; */
 }
 
 .mapButton {
@@ -35,8 +51,9 @@
     font-size: 0.9rem;
     cursor: pointer;
     transition: background-color 0.3s ease;
-    grid-column: 3;
-    justify-self: end;
+    margin-left: auto;
+    margin-right: 2rem;
+    /* justify-content: flex-end; */
 }
 
 .mapButton:hover {

--- a/ripview/src/components/Header.tsx
+++ b/ripview/src/components/Header.tsx
@@ -2,7 +2,11 @@ import Image from 'next/image';
 import styles from './Header.module.css';
 import { useRouter } from 'next/navigation';
 
-export default function Header() {
+interface HeaderProps {
+    title?: string;
+}
+
+export default function Header({ title = 'RipView' }: HeaderProps) {
     const router = useRouter();
     return (
         <div className={styles.navBar}>
@@ -14,7 +18,7 @@ export default function Header() {
                 height={38}
                 priority
             />
-            <h1>RipView</h1>
+            <h1>{title}</h1>
             <button className={styles.mapButton} onClick={() => router.push('/mapInput')}>
                 Map
             </button>

--- a/ripview/src/components/Header.tsx
+++ b/ripview/src/components/Header.tsx
@@ -1,9 +1,10 @@
 import Image from 'next/image';
 import styles from './Header.module.css';
 import { useRouter } from 'next/navigation';
+import { ReactNode } from 'react';
 
 interface HeaderProps {
-    title?: string;
+    title?: ReactNode;
     text: string;
     link: string;
 }

--- a/ripview/src/components/Header.tsx
+++ b/ripview/src/components/Header.tsx
@@ -4,9 +4,11 @@ import { useRouter } from 'next/navigation';
 
 interface HeaderProps {
     title?: string;
+    text: string;
+    link: string;
 }
 
-export default function Header({ title = 'RipView' }: HeaderProps) {
+export default function Header({ title = 'RipView', text, link }: HeaderProps) {
     const router = useRouter();
     return (
         <div className={styles.navBar}>
@@ -14,13 +16,13 @@ export default function Header({ title = 'RipView' }: HeaderProps) {
                 className={styles.lightLogo}
                 src='/favicon/favicon.svg'
                 alt='RipView logo'
-                width={180}
+                width={38}
                 height={38}
                 priority
             />
             <h1>{title}</h1>
-            <button className={styles.mapButton} onClick={() => router.push('/mapInput')}>
-                Map
+            <button className={styles.mapButton} onClick={() => router.push(link)}>
+                {text}
             </button>
         </div>
     );

--- a/ripview/src/components/Loading.module.css
+++ b/ripview/src/components/Loading.module.css
@@ -1,0 +1,109 @@
+.loadingContainer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--background);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.loadingContent {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+}
+
+.loadingAnimation {
+    position: relative;
+    width: 300px;
+    height: 60px;
+    overflow: hidden;
+}
+
+.train {
+    position: absolute;
+    top: 0;
+    font-size: 2rem;
+    color: var(--primary);
+    animation: moveTrain 8s infinite linear;
+    z-index: 2;
+}
+
+.track {
+    position: absolute;
+    bottom: 10px;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px;
+}
+
+.dot {
+    color: var(--gray-alpha-400);
+    font-size: 2rem;
+    line-height: 1;
+    animation: pulseDot 4s infinite linear;
+    opacity: 0.3;
+}
+
+.loadingMessage {
+    color: var(--foreground);
+    font-size: 1rem;
+    font-family: var(--font-geist-sans);
+    margin: 0;
+    animation: pulse 2s infinite;
+}
+
+@keyframes moveTrain {
+    0% {
+        transform: translateX(-50px) scaleX(1);
+    }
+    25% {
+        transform: translateX(350px) scaleX(1);
+    }
+    25.1% {
+        transform: translateX(350px) scaleX(-1);
+    }
+    50% {
+        transform: translateX(-50px) scaleX(-1);
+    }
+    50.1% {
+        transform: translateX(-50px) scaleX(1);
+    }
+    75% {
+        transform: translateX(350px) scaleX(1);
+    }
+    75.1% {
+        transform: translateX(350px) scaleX(-1);
+    }
+    100% {
+        transform: translateX(-50px) scaleX(-1);
+    }
+}
+
+@keyframes pulseDot {
+    0% {
+        opacity: 0.3;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.3;
+    }
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 0.6;
+    }
+    50% {
+        opacity: 1;
+    }
+}

--- a/ripview/src/components/Loading.tsx
+++ b/ripview/src/components/Loading.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import styles from './Loading.module.css';
+
+interface LoadingProps {
+    message?: string;
+}
+
+export default function Loading({ message = 'Loading...' }: LoadingProps) {
+    return (
+        <div className={styles.loadingContainer}>
+            <div className={styles.loadingContent}>
+                <div className={styles.loadingAnimation}>
+                    <div className={styles.train}>
+                        <i className="fas fa-train" aria-hidden="true"></i>
+                    </div>
+                    <div className={styles.track}>
+                        {Array.from({ length: 15 }, (_, i) => (
+                            <span key={i} className={styles.dot}>.</span>
+                        ))}
+                    </div>
+                </div>
+                <p className={styles.loadingMessage}>{message}</p>
+            </div>
+        </div>
+    );
+}

--- a/ripview/src/components/ScrollToTop.tsx
+++ b/ripview/src/components/ScrollToTop.tsx
@@ -1,59 +1,40 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './ScrollToTop.module.css';
 
 export default function ScrollToTop() {
     const [isVisible, setIsVisible] = useState(false);
 
-    // Debounced scroll handler
-    const toggleVisibility = useCallback(() => {
-        let scrollTimeout: NodeJS.Timeout;
+    const toggleVisibility = () => {
+        if (window.pageYOffset > 300) {
+            setIsVisible(true);
+        } else {
+            setIsVisible(false);
+        }
+    };
 
-        return () => {
-            const scrollPosition = window.scrollY || document.documentElement.scrollTop;
-            // Clear the timeout if it exists
-            clearTimeout(scrollTimeout);
-
-            // Set a new timeout
-            scrollTimeout = setTimeout(() => {
-                if (scrollPosition > 300) {
-                    setIsVisible(true);
-                } else {
-                    setIsVisible(false);
-                }
-            }, 100); // 100ms delay for smoother transition
-        };
-    }, []);
-
-    // Smooth scroll to top function
     const scrollToTop = () => {
         window.scrollTo({
             top: 0,
-            behavior: 'smooth'
+            behavior: 'smooth',
         });
     };
 
     useEffect(() => {
-        // Wait for DOM to be fully loaded
-        if (typeof window !== 'undefined') {
-            const handleScroll = toggleVisibility();
-            window.addEventListener('scroll', handleScroll);
-
-            // Cleanup
-            return () => {
-                window.removeEventListener('scroll', handleScroll);
-            };
-        }
-    }, [toggleVisibility]);
+        window.addEventListener('scroll', toggleVisibility);
+        return () => {
+            window.removeEventListener('scroll', toggleVisibility);
+        };
+    }, []);
 
     return (
-        <button
-            className={`${styles.scrollToTop} ${isVisible ? styles.visible : ''}`}
-            onClick={scrollToTop}
-            aria-label="Scroll to top"
-        >
-            <i className={`fas fa-arrow-up ${styles.icon}`} style={{ color: 'inherit' }}></i>
-        </button>
+        <>
+            {isVisible && (
+                <div className={styles.scrollToTop} onClick={scrollToTop}>
+                    ↑
+                </div>
+            )}
+        </>
     );
 }

--- a/ripview/src/components/StationSelect.module.css
+++ b/ripview/src/components/StationSelect.module.css
@@ -1,26 +1,29 @@
 .stationSelect {
     position: relative;
     width: 100%;
-    margin-bottom: 1rem;
+    max-width: 30rem;
+    margin: 0 auto 0rem auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .stationSelect label {
     display: grid;
-    grid-template-columns: 4rem 1fr;
-    align-items: center;
+    grid-template-columns: 4.5rem 1fr;
     gap: 1rem;
+    align-items: center;
     width: 100%;
 }
 
 .stationSelect input[type="text"] {
-    padding: 0.75rem;
-    border: 0.0625rem solid var(--gray-alpha-200);
-    border-radius: 0.5rem;
-    background-color: var(--background);
-    color: var(--foreground);
-    font-family: var(--font-geist-sans);
     width: 100%;
-    transition: border-color 0.2s ease;
+    padding: 0.75rem;
+    border: 1px solid var(--gray-alpha-200);
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    background-color: var(--background);
+    color: inherit;
 }
 
 .stationSelect input[type="text"]:focus {
@@ -31,16 +34,15 @@
 .dropdown {
     position: absolute;
     top: 100%;
-    left: 5rem;
+    left: 0;
     right: 0;
     max-height: 15rem;
     overflow-y: auto;
     background-color: var(--background);
-    border: 0.0625rem solid var(--gray-alpha-200);
+    border: 1px solid var(--gray-alpha-200);
     border-radius: 0.5rem;
-    margin-top: 0.25rem;
-    box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
-    z-index: 1000;
+    margin-top: 0.5rem;
+    z-index: 10;
 }
 
 .dropdown li {
@@ -60,12 +62,14 @@
 }
 
 @media (max-width: 37.5rem) {
+    .stationSelect {
+        max-width: 20rem;
+    }
     .stationSelect label {
         grid-template-columns: 3.5rem 1fr;
         gap: 0.5rem;
     }
-
     .dropdown {
-        left: 4rem;
+        left: 0;
     }
-} 
+}

--- a/ripview/src/components/StationSelect.module.css
+++ b/ripview/src/components/StationSelect.module.css
@@ -34,7 +34,7 @@
 .dropdown {
     position: absolute;
     top: 100%;
-    left: 0;
+    left: calc(4.5rem + 1rem); /* Align with input field (label width + gap) */
     right: 0;
     max-height: 15rem;
     overflow-y: auto;
@@ -43,6 +43,7 @@
     border-radius: 0.5rem;
     margin-top: 0.5rem;
     z-index: 10;
+    width: calc(100% - 4.5rem - 1rem); /* Make width match the input field */
 }
 
 .dropdown li {
@@ -70,6 +71,7 @@
         gap: 0.5rem;
     }
     .dropdown {
-        left: 0;
+        left: calc(3.5rem + 0.5rem); /* Align with input field (label width + gap) */
+        width: calc(100% - 3.5rem - 0.5rem); /* Make width match the input field */
     }
 }

--- a/ripview/src/components/StationSelect.tsx
+++ b/ripview/src/components/StationSelect.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, ChangeEvent, KeyboardEvent } from 'react';
 import styles from './StationSelect.module.css';
 
 interface StationSelectProps {
@@ -37,13 +37,13 @@ export default function StationSelect({ label, name, onChange, records }: Statio
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, []);
 
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
         setInputValue(e.target.value);
         setIsOpen(true);
     };
 
     // Handle key down event to select the first match when tab is pressed
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Tab' && filteredStations.length > 0) {
             const firstMatch = filteredStations[0];
             setInputValue(String(firstMatch[1]));

--- a/ripview/src/components/SubHeader.module.css
+++ b/ripview/src/components/SubHeader.module.css
@@ -1,0 +1,38 @@
+.subHeader {
+    background-color: var(--background);
+    border-bottom: 0.0625rem solid var(--gray-alpha-200);
+    position: fixed;
+    top: 4rem;
+    z-index: 9;
+    backdrop-filter: blur(8px);
+    width: 100%;
+    height: 3rem;
+    display: flex;
+    align-items: center;
+}
+
+.content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    height: 100%;
+    padding: 0 2rem;
+}
+
+.leftSection {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    height: 100%;
+}
+
+.timeInfo {
+    color: var(--gray-alpha-900);
+    font-size: 0.9rem;
+    font-family: var(--font-geist-sans);
+    white-space: nowrap;
+    padding-left: 0.5rem;
+}

--- a/ripview/src/components/SubHeader.module.css
+++ b/ripview/src/components/SubHeader.module.css
@@ -16,7 +16,7 @@
     margin: 0 auto;
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
     width: 100%;
     height: 100%;
     padding: 0 2rem;
@@ -29,10 +29,49 @@
     height: 100%;
 }
 
+.rightSection {
+    display: flex;
+    align-items: center;
+    height: 100%;
+}
+
 .timeInfo {
     color: var(--gray-alpha-900);
     font-size: 0.9rem;
     font-family: var(--font-geist-sans);
     white-space: nowrap;
     padding-left: 0.5rem;
+}
+
+.closestTripButton {
+    padding: 0.5rem;
+    width: fit-content;
+    border: 1px solid var(--gray-alpha-200);
+    border-radius: 0.375rem;
+    background-color: transparent;
+    color: var(--foreground);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    height: 2rem;
+}
+
+.closestTripButton:hover {
+    background-color: var(--gray-alpha-100);
+    transform: translateX(2px);
+}
+
+.closestTripButton i {
+    font-size: 1rem;
+}
+
+@media (max-width: 37.5rem) {
+    .nextTripButton {
+        padding: 0.375rem 0.75rem;
+        min-width: 1.75rem;
+    }
 }

--- a/ripview/src/components/SubHeader.module.css
+++ b/ripview/src/components/SubHeader.module.css
@@ -2,7 +2,9 @@
     background-color: var(--background);
     border-bottom: 0.0625rem solid var(--gray-alpha-200);
     position: fixed;
-    top: 4rem;
+    top: 5rem;
+    left: 0;
+    right: 0;
     z-index: 9;
     backdrop-filter: blur(8px);
     width: 100%;
@@ -44,34 +46,88 @@
 }
 
 .closestTripButton {
-    padding: 0.5rem;
-    width: fit-content;
+    padding: 0.5rem 1rem;
     border: 1px solid var(--gray-alpha-200);
-    border-radius: 0.375rem;
-    background-color: transparent;
-    color: var(--foreground);
+    border-radius: 0.5rem;
+    font-size: 0.9rem;
     cursor: pointer;
     transition: all 0.2s ease;
-    margin: 0;
+    background-color: var(--background);
+    color: inherit;
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.875rem;
-    height: 2rem;
 }
 
 .closestTripButton:hover {
     background-color: var(--gray-alpha-100);
-    transform: translateX(2px);
 }
 
-.closestTripButton i {
-    font-size: 1rem;
+.mobileText {
+    display: none;
 }
 
-@media (max-width: 37.5rem) {
-    .nextTripButton {
-        padding: 0.375rem 0.75rem;
-        min-width: 1.75rem;
+/* Mobile Styles */
+@media (max-width: 768px) {
+    .content {
+        padding: 0 1rem;
+    }
+
+    .timeInfo {
+        font-size: 0.85rem;
+    }
+
+    .closestTripButton {
+        padding: 0.5rem 0.75rem;
+        font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .content {
+        padding: 0 0.75rem;
+    }
+
+    .leftSection {
+        gap: 0.5rem;
+    }
+
+    .timeInfo {
+        font-size: 0.8rem;
+        padding-left: 0.25rem;
+    }
+
+    .closestTripButton {
+        padding: 0.4rem 0.6rem;
+        font-size: 0.8rem;
+    }
+
+    .desktopText {
+        display: none;
+    }
+
+    .mobileText {
+        display: inline;
+    }
+}
+
+@media (max-width: 360px) {
+    .content {
+        padding: 0 0.5rem;
+    }
+
+    .timeInfo {
+        font-size: 0.75rem;
+    }
+
+    .closestTripButton {
+        padding: 0.35rem 0.5rem;
+        font-size: 0.75rem;
+    }
+}
+
+@media (display-mode: standalone) {
+    .subHeader {
+        top: 7rem !important;
     }
 }

--- a/ripview/src/components/SubHeader.tsx
+++ b/ripview/src/components/SubHeader.tsx
@@ -1,0 +1,19 @@
+import styles from './SubHeader.module.css';
+import BackButton from './BackButton';
+
+interface SubHeaderProps {
+    timeInfo: string;
+}
+
+export default function SubHeader({ timeInfo }: SubHeaderProps) {
+    return (
+        <div className={styles.subHeader}>
+            <div className={styles.content}>
+                <div className={styles.leftSection}>
+                    <BackButton />
+                    <span className={styles.timeInfo}>{timeInfo}</span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/ripview/src/components/SubHeader.tsx
+++ b/ripview/src/components/SubHeader.tsx
@@ -3,9 +3,11 @@ import BackButton from './BackButton';
 
 interface SubHeaderProps {
     timeInfo: string;
+    onClosestTrip?: () => void;
+    hasClosestTrip?: boolean;
 }
 
-export default function SubHeader({ timeInfo }: SubHeaderProps) {
+export default function SubHeader({ timeInfo, onClosestTrip, hasClosestTrip }: SubHeaderProps) {
     return (
         <div className={styles.subHeader}>
             <div className={styles.content}>
@@ -13,6 +15,18 @@ export default function SubHeader({ timeInfo }: SubHeaderProps) {
                     <BackButton />
                     <span className={styles.timeInfo}>{timeInfo}</span>
                 </div>
+                {hasClosestTrip && onClosestTrip && (
+                    <div className={styles.rightSection}>
+                        <button 
+                            onClick={onClosestTrip}
+                            className={styles.closestTripButton}
+                            aria-label="Go to closest trip"
+                        >
+                            <span>Go to Closest Trip</span>
+                            <i className="fas fa-arrow-right" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/ripview/src/components/SubHeader.tsx
+++ b/ripview/src/components/SubHeader.tsx
@@ -22,7 +22,8 @@ export default function SubHeader({ timeInfo, onClosestTrip, hasClosestTrip }: S
                             className={styles.closestTripButton}
                             aria-label="Go to closest trip"
                         >
-                            <span>Go to Closest Trip</span>
+                            <span className={styles.desktopText}>Go to Closest Trip</span>
+                            <span className={styles.mobileText}>Closest Trip</span>
                             <i className="fas fa-arrow-right" aria-hidden="true"></i>
                         </button>
                     </div>

--- a/ripview/src/utils/getData.ts
+++ b/ripview/src/utils/getData.ts
@@ -6,10 +6,11 @@ export function getStationIdEntries() {
     return records;
 }
 
-export function getStationNameFromId(id: string) {
+export function getStationNameFromId(id: string): string | null {
     if (id === null) {
         return null;
     }
     const records = getStationIdEntries();
-    return records.filter((a) => (a[2] as string) == id)[0][1];
+    const station = records.filter((a) => (a[2] as string) == id)[0];
+    return station ? station[1] as string : null;
 }


### PR DESCRIPTION
## Summary

### 05/02/2025 - [Initial Work on Cascading Tabs](https://github.com/Edwintang2005/ripview/pull/14/commits/d094fd04e81a4daef46a6b454e5d0e27a746aec3)
- Added in cascading functionality to clicking on the tabs in the tripPlanning page.
- Formatted and moved around some information to go within the cascaded opening.
- Added in some colour depending on their respective train lines.
- Removed "From" and "To" and suburbs from the station information within the cascaded tab.

### 05/02/2025 - [Fixed Time Duration Calculation, Added Vertical Strip, Formatted Leg Information](https://github.com/Edwintang2005/ripview/pull/14/commits/f32ce7c985a40f1c4217e8e4578013b79cc91d7b)
- In `apiCalls.tsx`, fixed up the functions to calculate the duration of each trip. The problem was because the api would return some arrival times for the "From" stations with seconds included, for example 05:19:42 and so when performing the calculation, the time taken would actually be taken from 05:20:00 and therefore this would lead to the duration being off by 1 minute.
- Added a vertical strip of colour to the legs depending on their respective train lines.
- Formatted the leg information better so that it still includes the station line and adding some padding between the times and the stations.

### 06/02/2025 - [v1/reformatted-trip-option-tabs](https://github.com/Edwintang2005/ripview/pull/14/commits/7eb4936e19ebaef060e6299d297f1e240fe2c373)
- Reformatted the tab before it is clicked on so that station information is displayed with only the vital information.
- Added a "Departs in:" section to show the user how long before the train arrives.
- Played around with moving the train line change warning.
- Centered text vertically.
- Added padding.
- Added some padding in the cascading section.

### 06/02/2025 - [v2/reformatted-trip-option-tabs](https://github.com/Edwintang2005/ripview/pull/14/commits/6db1fe5f8cae0d65b236199f9b53bef1b931322c)
- Moved the train line change from the right side with the "Departs in" time to just underneath the "From" station.
- Kept the rest of the text vertically aligned. Added the "train line change" so that the position is absolute and doesn't affect the spacing of the other text such as the "From" station.
- Removed some redundant `.css` styling.
- Fixed `expandIcon` so that the arrow rotates on itself correctly. Added some padding to the right from the tripSummary box.

### 06/02/2025 - [v3/reformatted-trip-option-tabs/Scroll to Trip Option on Click](https://github.com/Edwintang2005/ripview/pull/14/commits/51c54cfb625311a2468251f8926c64be9f1510b5)
- Modified `handleTripClick()` function to focus on selected trip options so that the user doesn't have to scroll as much. The sequence of the function now closes the original trip option (if opened), then opens the new trip option that is clicked on and then scrolls to it, leaving some offset from the top as some padding. There are some small delays within this function for a more smooth transition.
- Adjusted the transitions so it's not as jittery and has a smoother transition.
- Added a cubic_bezier transition so it has a smooth start, quick middle, and a gentle end for the transition.

### 06/02/2025 - [Re-added Displaying Time Preference, Routine Update on Time, Fixed Issues with Arrive-by Time, Wait and Departed Time Implementation](https://github.com/Edwintang2005/ripview/pull/14/commits/65367530335db7a644c9a243035772d6d6c2c54a)
- Re-added Displaying Time Preference so that it displays to the user whether they selected the current time or a specific time such as "Arrive By" or "Depart At".
- Added in a section to display to the user how many minutes before the train arrives and also included logic for when the train has departed. Colour coded the departed (red) and waiting (green) for better UI. 
- Included logic to update the current time and the wait time so that it updates the time in the time preference and the wait time for that, real-time updates feel.
- Tested the "Arrive By" specific time settings and fixed issues such as trips being displayed that didn't meet the user requirements. Added in a section to also display to the user how much time between the actual arrival time at the final destination station and the "Arrive By" time so that users can take into account how much time they have when planning trips.
- Removed some redundant and unnecessary code, still need to refine time calculations and logic as there's a lot of moving parts to it.

### 07/02/2025 - [Updated Total Duration to include wait times](https://github.com/Edwintang2005/ripview/pull/14/commits/ed7b1cf6a69ea6a147aaa4e640af911cbbcd5367)
- Updated `calculateTotalDuration` function to include waiting times between legs.
- Grouped the trip information into legs by using departure and arrival points.
- Calculate the travel time from each leg.
- Add the waiting time between legs (if any).
- Resized the waiting time indicator to be smaller.

### 07/02/2025 - [Added an indicator in extended details to show wait time between trains on multiple legs](https://github.com/Edwintang2005/ripview/pull/14/commits/46ea04ff3c58afac30e7c2bb7753fdfa09522f30)
- On trips with multiple legs, modified the separator to also display the time needed to wait before the next train arrives.
- Fixed some padding and spacing.

### 07/02/2025 (pushed at midnight on the next day but all work was done on this date) - [Semi-implemented previous trips, next trip focus 
functionality and real time update](https://github.com/Edwintang2005/ripview/pull/14/commits/1bbf141a2d437495230dba92b493651f19510988)
- Updated `planTrip` function in `apiCalls.tsx` to also return information about past trips.
- Added in past trips to the trip planning page so that the user can refer back and see past trips that have already departed.
- Added in a real time updating tag that says "Next Trip" so the user can keep track of the next upcoming trip. Similar to how the real time logic works from a previous commit: [Re-added Displaying Time Preference, Routine Update on Time, Fixed Issues with Arrive-by Time, Wait and Departed Time Implementation](https://github.com/Edwintang2005/ripview/pull/14/commits/65367530335db7a644c9a243035772d6d6c2c54a).
- Documented several other notes for next iterations.

### 09/02/2025 (same as above, pushed after midnight) - [Overhaul of Frontend, Displaying more past and future trips, minor fixes to Time Preference Settings, SubHeader Component](https://github.com/Edwintang2005/ripview/pull/14/commits/d06b024ebc16a3b08dc0f544fb94568c812eb852)
- Reformatted frontend on trip planning page.
- Made trip options smaller.
- Fixed up issues with some formatting such as time, titles, information.
- Adjusted `Header.tsx` component to accept a title prop.
- Minor fixes to time preference settings so that it works as intended. Only show trips according to the requested preference such as arrive by a certain time or depart at a certain time.
- Added a `SubHeader.tsx` component to go underneath the `Header.tsx` component in the trip planning page.
- Modified `apiCalls.tsx` to allow for more past and future trips.

#### Refining `apiCalls.tsx`

1. **Parallel API Calls**: Implemented concurrent fetching using Promise.all() to make multiple API requests simultaneously, significantly reducing total request time.

2. **Smart Time Intervals**: 
   - For "arrive by": Strategically samples time points before the requested arrival time
   - For "depart at": Samples times after the current time
   - Uses 1-hour intervals to provide good coverage while minimizing API calls

3. **Request Deduplication**: 
   - Maintains a Set of unique date-time combinations
   - Prevents redundant API calls for the same time points
   - Particularly effective when intervals overlap across different time ranges

4. **Efficient Data Processing**:
   - Processes responses in parallel as they arrive
   - Sorts trips based on arrival/departure times depending on user preference
   - Filters out duplicate trips early in the pipeline

These improvements significantly reduced API load and response times while maintaining comprehensive trip coverage.

### 09/02/2025 (same as above, pushed after midnight) - [Added a small section in the depart at preference to show how many minutes after requested time](https://github.com/Edwintang2005/ripview/pull/14/commits/8a3d0be62f2ad5521c4848ba4e3e6baa6e901360)
- Just like in the arrive by setting, added in a small section of information that tells the user how many minutes after the requested time for that specific trip.
- For example, if the user wants to depart at 11am, then the app will find trips that are at 11am or after and then if it finds a trip that is at 11:15am, it will display **15 minutes after requested time**.

### 09/02/2025 (same as above, pushed after midnight) - [Removed some unnecessary code and changed train line change warning](https://github.com/Edwintang2005/ripview/pull/14/commits/4b12bd98d347cc4374bc69faaac4fd8d64ed847d)
- Did not lint check but removed some unnecessary functions and comments that are no longer needed.
- Moved and changed train line change warning.
- Note: will most likely change the train line warning again, originally it was underneath the "From Station" but now it has moved to above the wait timer but it may move underneath or somewhere else again.

### 10/02/2025 - [Fixed focusing on trip option after click](https://github.com/Edwintang2005/ripview/pull/14/commits/e13ab235eba4c41f8f3824f260c0fc3bd269b49f)
- Updated `useEffect` to ensure more consistency when clicking on a new trip option so that it gets scrolled to when clicked on.

### 10/02/2025 - [Aligned real time updates on time with actual time rather than every 60 seconds](https://github.com/Edwintang2005/ripview/pull/14/commits/646c8c7dc026a344c2305573d94bd882f1f18e7f)
- Updated `useEffect` so that it calculates and adds correct amount of seconds so that it lines up with the world time so that it updates in real time accordingly.

### 10/02/2025 - [Minor fix to total duration, slight modification to wait timer between legs, updated filters on edge case](https://github.com/Edwintang2005/ripview/pull/14/commits/d668370786043add67743df1a8f9feb58611cb4e)
- Fixed total duration being miscalculated for cases where it goes into the next day (due to date being appended to the end trip).
- Created a small container for the wait time between legs for better visual hierarchy.
- Fixed an edge case where sometimes it would show a trip option that didn't abide by user's preferences.

### 10/02/2025 - [Refined helper functions, removed unnecessary code](https://github.com/Edwintang2005/ripview/pull/14/commits/951bae4a0a76e676b29e303edb442c4c58672e48)
- Condensed time related functions.
- Condensed formatting related functions.
- Removed some debugging and console.log statements.
- Refined overall code to remove unnecessary code and refined code.

### 11/02/2025 - [Added Go to Closest Trip Button](https://github.com/Edwintang2005/ripview/pull/14/commits/ab913b7e78afb5464d784dc91bc65da64a3c6d00)
- Added in a "Go to Closest Trip" button into the `SubHeader.tsx` component and styled it accordingly.
- This button will always show in the subheader and allows for the user to always click on it whenever they like to be scrolled back to the closest trip without having to look for the closest trip to departure.

### 11/02/2025 - [Added a train loading animation component](https://github.com/Edwintang2005/ripview/pull/14/commits/30ab779fe508bdfd51768a52b7abb23c2f80dcb3)
- Created a `Loading.tsx` and Loading.module.css` so that it is a reusable component to add in an animation for loading pages.
- Adjusted animation slightly and tested out different styles and settled for an animated train icon travelling across dots.
- May choose to change the train icon.

### 28/02/2025 - [Refining mobile responsiveness for 480px screens](https://github.com/Edwintang2005/ripview/pull/14/commits/0c8bfdc7bd2cc8f8d43d6f26e3ff5b04110b0bf2)
- Refined the mobile responsiveness for smaller screens such as 480px.
- Adjusted several functions and added some utility functions for formatting such as simplifying the station names.
- Adjusted some spacing in both smaller and larger screens to account for small changes in format such as padding and the expandIcon.
- Stacked the "From" and "To" stations vertically rather than displaying them horizontally for smaller screens.
- Added a glow and a blue outline glow to the closest trip for even more visual noticeability.
- Adjusted the warning label about train line changes to "[no.] swap(s)" to make the label smaller in width.
- Fixed up dropdown issue expanding further than expected in the home screen when searching for stations.
- Cleaned up some code regarding the `tripPlanning.module.css` file and removed some conflicting code.

### Next steps
- [x] Reformat the station information before the cascade.
- [x] Move the 1 train line change warning.
- [x] Add back in the Train Line information underneath duration.
- [x] Fix duration calculation on the frontend.
- Refine and experiment with different styles.
- [x] Re-add the "Showing times for: [current time/specific time], broke the logic.
- Add some more train line colours.
- Service information alerts.
- Experiment with font emphasis, font sizes and colours.
- [x] Show more past and future trips (max first trip of the day and also about 24 hours forward)
- [x] Need to format the wait timer for trips that are over 24 hours.
- Detect if trip is a limited stops service or an all stops service.
- [x] Create a new section to house some general information such as the "From" and "To" station and the time preference that the user has selected for easier reference. So that they don't need to scroll all the way to the top in order to view this information.
- [x] Fix issue with total duration of trip displaying an incorrect time for trips that are from one day into the next day, most likely cause of the time calculation for 24 hour time. Was due to date being appended to the next day (since it wasn't the current day)
- [x] Add a go to closest trip button so that users don't have to go looking for their next closest trip.
- Fix focus on trip options when clicking on them, inconsistent spacing each time. Mostly fixed but seems to have some edge cases where it doesn't scroll with the correct offset if there are multiple legs in a trip since it is bigger.